### PR TITLE
fix ubiCommunityDailyState and globalDailyState migrations

### DIFF
--- a/src/database/migrations/z1633121072-update-ubiCommunityDailyState.js
+++ b/src/database/migrations/z1633121072-update-ubiCommunityDailyState.js
@@ -11,8 +11,8 @@ module.exports = {
         const today = (new Date()).toISOString().split('T')[0];
         await queryInterface.sequelize.query(
             `update ubi_community_daily_state
-            set volume = CASE WHEN ubi_community_daily_state.date = TOTAL.date THEN TOTAL.volume ELSE 0 END,
-                transactions = CASE WHEN ubi_community_daily_state.date = TOTAL.date THEN TOTAL.txs ELSE 0 END
+            set volume = TOTAL.volume,
+                transactions = TOTAL.txs
             from (
                 SELECT COALESCE(sum(beneficiarytransaction.amount), 0) volume, count(beneficiarytransaction.tx) txs, community.id, date
                 from beneficiarytransaction
@@ -21,7 +21,7 @@ module.exports = {
                 where date BETWEEN '${startDate}' and '${today}'
                 group by community.id, date
             ) as TOTAL
-            WHERE "communityId" = TOTAL.id and ubi_community_daily_state.date BETWEEN '${startDate}' and '${today}'`
+            WHERE "communityId" = TOTAL.id and ubi_community_daily_state.date = TOTAL.date`
         );
     },
 

--- a/src/database/migrations/z1633121095-update-globalDailyState.js
+++ b/src/database/migrations/z1633121095-update-globalDailyState.js
@@ -142,11 +142,13 @@ module.exports = {
         while (dateToCount <= today) {
             const totals = (
                 await queryInterface.sequelize.query(
-                    `select COALESCE(sum(amount), 0) volume, count(beneficiarytransaction.tx) txs
-                     from beneficiarytransaction 
+                    `select COALESCE(sum(transactions.amount), 0) volume, count(transactions.tx) txs from (
+                        select distinct beneficiarytransaction.amount, beneficiarytransaction.tx
+                        from beneficiarytransaction
                         inner join beneficiary on beneficiary.address = beneficiarytransaction.beneficiary
-                            inner join community on community."publicId" = beneficiary."communityId"
-                     where community.visibility = 'public' and date <= '${dateToCount.toISOString().split('T')[0]}'`,
+                                inner join community on community."publicId" = beneficiary."communityId"
+                         where community.visibility = 'public' and date <= '${dateToCount.toISOString().split('T')[0]}'
+                    ) as transactions`,
                     {
                         type: Sequelize.QueryTypes.SELECT,
                     }
@@ -155,11 +157,13 @@ module.exports = {
 
             const individual = (
                 await queryInterface.sequelize.query(
-                    `select COALESCE(sum(amount), 0) volume, count(beneficiarytransaction.tx) txs
-                     from beneficiarytransaction
+                    `select COALESCE(sum(transactions.amount), 0) volume, count(transactions.tx) txs from (
+                        select distinct beneficiarytransaction.amount, beneficiarytransaction.tx
+                        from beneficiarytransaction
                         inner join beneficiary on beneficiary.address = beneficiarytransaction.beneficiary
-                            inner join community on community."publicId" = beneficiary."communityId"
-                     where community.visibility = 'public' and date = '${dateToCount.toISOString().split('T')[0]}'`,
+                                inner join community on community."publicId" = beneficiary."communityId"
+                         where community.visibility = 'public' and date = '${dateToCount.toISOString().split('T')[0]}'
+                         ) as transactions`,
                     {
                         type: Sequelize.QueryTypes.SELECT,
                     }


### PR DESCRIPTION
## Changes
@obernardovieira indeed both migrations were incorrect.
the `update-ubiCommunityDailyState` migration, in my local tests, was working, however, testing with the production dump I could find the errors and fix the query.

also the `update-globalDailyState` migration was working in my local tests as I didn't foresee a situation: beneficiaries who are part of more than one community. So, when `sum` and `count` are done by joining the beneficiary table, it occurs that some records are duplicated, summing and counting more than once.
for that I tried to use only the `distinct` in count and sum ( `sum(distinct amount)`, `count(distinct tx)` ). In count worked perfectly, but I couldn't use it in sum, because it aggregates equal values.
to get around this, I decided to make a subselect.

I tested it with the production dump and this time everything is correct! if you can test it again and if you have any suggestions please let me know

## New

<!---
Specify what's new. New endpoints, etc.
-->

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->