### PR TITLE
list ambassadors communities

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -37,6 +37,7 @@
         "express-rate-limit": "5.5.1",
         "helmet": "4.6.0",
         "jsonwebtoken": "8.5.1",
+        "libphonenumber-js": "1.9.50",
         "module-alias": "2.2.2",
         "morgan": "1.10.0",
         "rate-limit-redis": "2.1.0",

--- a/packages/api/src/controllers/v2/community/list.ts
+++ b/packages/api/src/controllers/v2/community/list.ts
@@ -1,5 +1,6 @@
 import { services } from '@impactmarket/core';
-import { Request, Response } from 'express';
+import { Response } from 'express';
+import { RequestWithUser } from 'middlewares/core';
 
 import { standardResponse } from '../../../utils/api';
 
@@ -9,9 +10,9 @@ class CommunityController {
         this.communityService = new services.ubi.CommunityListService();
     }
 
-    list = (req: Request, res: Response) => {
+    list = (req: RequestWithUser, res: Response) => {
         this.communityService
-            .list(req.query)
+            .list(req.query, req.user?.address)
             .then((r) => standardResponse(res, 200, true, r))
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));
     };

--- a/packages/api/src/routes/v2/community/list.ts
+++ b/packages/api/src/routes/v2/community/list.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 
 import { CommunityController } from '../../../controllers/v2/community/list';
+import { optionalAuthentication } from '../../../middlewares';
 
 export default (route: Router): void => {
     const controller = new CommunityController();
@@ -74,5 +75,5 @@ export default (route: Router): void => {
      *       "200":
      *         description: OK
      */
-    route.get('/:query?', controller.list);
+    route.get('/:query?', optionalAuthentication, controller.list);
 };

--- a/packages/core/src/services/ubi/community/list.ts
+++ b/packages/core/src/services/ubi/community/list.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+import parsePhoneNumber from 'libphonenumber-js';
 import { Op, literal, OrderItem, WhereOptions, Includeable } from 'sequelize';
 import { Literal } from 'sequelize/types/lib/utils';
 
@@ -18,19 +19,22 @@ import { CommunityDetailsService } from './details';
 export class CommunityListService {
     communityDetailsService = new CommunityDetailsService();
 
-    public async list(query: {
-        orderBy?: string;
-        filter?: string;
-        name?: string;
-        country?: string;
-        extended?: string;
-        offset?: string;
-        limit?: string;
-        lat?: string;
-        lng?: string;
-        fields?: string;
-        status?: 'valid' | 'pending';
-    }): Promise<{ count: number; rows: CommunityAttributes[] }> {
+    public async list(
+        query: {
+            orderBy?: string;
+            filter?: string;
+            name?: string;
+            country?: string;
+            extended?: string;
+            offset?: string;
+            limit?: string;
+            lat?: string;
+            lng?: string;
+            fields?: string;
+            status?: 'valid' | 'pending';
+        },
+        ambassadorAddress?: string
+    ): Promise<{ count: number; rows: CommunityAttributes[] }> {
         let extendedWhere: WhereOptions<CommunityAttributes> = {};
         const orderOption: OrderItem[] = [];
         const orderOutOfFunds = {
@@ -87,12 +91,47 @@ export class CommunityListService {
 
         if (query.status === 'pending') {
             const communityProposals = await this._getOpenProposals();
+            if (ambassadorAddress) {
+                const ambassador = (await models.appUser.findOne({
+                    attributes: [],
+                    include: [
+                        {
+                            model: models.appUserTrust,
+                            as: 'trust',
+                            attributes: ['phone'],
+                        },
+                    ],
+                    where: {
+                        address: ambassadorAddress,
+                    },
+                })) as any;
+                const phone = ambassador?.trust[0]?.phone;
+                if (phone) {
+                    const parsePhone = parsePhoneNumber(phone);
+                    extendedWhere = {
+                        ...extendedWhere,
+                        country: parsePhone?.country,
+                    };
+                } else {
+                    throw new BaseError(
+                        'AMBASSADOR_NOT_FOUND',
+                        'Ambassador not found'
+                    );
+                }
+            }
             extendedWhere = {
                 ...extendedWhere,
                 requestByAddress: {
                     [Op.notIn]: communityProposals,
                 },
             };
+        } else {
+            if (ambassadorAddress) {
+                extendedWhere = {
+                    ...extendedWhere,
+                    ambassadorAddress,
+                };
+            }
         }
 
         if (query.orderBy) {
@@ -193,17 +232,19 @@ export class CommunityListService {
                 }
             }
         } else {
-            beneficiariesState = await this._getBeneficiaryState(
-                {
-                    status: query.status,
-                    limit: query.limit,
-                    offset: query.offset,
-                },
-                extendedWhere
-            );
-            contractAddress = beneficiariesState!.map((el) =>
-                ethers.utils.getAddress(el.id)
-            );
+            if (query.status !== 'pending') {
+                beneficiariesState = await this._getBeneficiaryState(
+                    {
+                        status: query.status,
+                        limit: query.limit,
+                        offset: query.offset,
+                    },
+                    extendedWhere
+                );
+                contractAddress = beneficiariesState!.map((el) =>
+                    ethers.utils.getAddress(el.id)
+                );
+            }
         }
 
         let include: Includeable[];
@@ -329,8 +370,8 @@ export class CommunityListService {
         //     communitiesId = result.map((el) => el.id);
         // }
 
-        // remove empty elements 
-        communitiesId = communitiesId.filter(Number) 
+        // remove empty elements
+        communitiesId = communitiesId.filter(Number);
 
         let states: ({
             communityId: number;

--- a/packages/core/tests/integration/v2/community.test.ts
+++ b/packages/core/tests/integration/v2/community.test.ts
@@ -1624,5 +1624,140 @@ describe('community service v2', () => {
                 expect(pending.count).to.be.equal(2);
             });
         });
+
+        describe('ambassador list', () => {
+            afterEach(async () => {
+                await truncate(sequelize, 'Beneficiary');
+                await truncate(sequelize, 'Community');
+                returnProposalsSubgraph.resetHistory();
+                returnClaimedSubgraph.resetHistory();
+            });
+
+            after(async () => {
+                returnProposalsSubgraph.restore();
+                returnClaimedSubgraph.restore();
+            });
+
+            it('list pending communities in the ambassadors country', async () => {
+                const ambassadors = await UserFactory({ n: 2, props: [
+                    {
+                        phone: '+12025550167',
+                    },
+                    {
+                        phone: '+5514999420299'
+                    }
+                ]});
+                const communities = await CommunityFactory([
+                    {
+                        requestByAddress: users[0].address,
+                        started: new Date(),
+                        status: 'pending',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -23.4378873,
+                            longitude: -46.4841214,
+                        },
+                        country: 'BR',
+                    },
+                    {
+                        requestByAddress: users[2].address,
+                        started: new Date(),
+                        status: 'pending',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -23.4378873,
+                            longitude: -46.4841214,
+                        },
+                        country: 'VE',
+                    },
+                ]);
+
+                returnProposalsSubgraph.returns([]);
+                returnClaimedSubgraph.returns([]);
+                returnCommunityEntities.returns([]);
+
+                const result = await communityListService.list({ status: 'pending' }, ambassadors[0].address);
+
+                expect(result.count).to.be.equal(1);
+                expect(result.rows[0].id).to.be.equal(communities[0].id);
+            });
+
+            it('list communities where ambassador', async () => {
+                const ambassadors = await UserFactory({ n: 2, props: [
+                    {
+                        phone: '+12025550167',
+                    },
+                    {
+                        phone: '+5514999420299'
+                    }
+                ]});
+                const communities = await CommunityFactory([
+                    {
+                        requestByAddress: users[0].address,
+                        started: new Date(),
+                        status: 'valid',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -23.4378873,
+                            longitude: -46.4841214,
+                        },
+                        country: 'BR',
+                        ambassadorAddress: ambassadors[0].address
+                    },
+                    {
+                        requestByAddress: users[2].address,
+                        started: new Date(),
+                        status: 'valid',
+                        visibility: 'public',
+                        contract: {
+                            baseInterval: 60 * 60 * 24,
+                            claimAmount: '1000000000000000000',
+                            communityId: 0,
+                            incrementInterval: 5 * 60,
+                            maxClaim: '450000000000000000000',
+                        },
+                        hasAddress: true,
+                        gps: {
+                            latitude: -23.4378873,
+                            longitude: -46.4841214,
+                        },
+                        country: 'VE',
+                        ambassadorAddress: ambassadors[1].address
+                    },
+                ]);
+
+                returnClaimedSubgraph.returns([]);
+                returnCommunityEntities.returns([]);
+
+                const result = await communityListService.list({}, ambassadors[0].address);
+
+                expect(result.count).to.be.equal(1);
+                expect(result.rows[0].id).to.be.equal(communities[0].id);
+            });
+        });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10269,6 +10269,11 @@ libnpmpublish@^4.0.0:
     semver "^7.1.3"
     ssri "^8.0.1"
 
+libphonenumber-js@1.9.50:
+  version "1.9.50"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.50.tgz#f5028a2c4cc47a69d69a0de3629afad97a613712"
+  integrity sha512-cCzQPChw2XbordcO2LKiw5Htx5leHVfFk/EXkxNHqJfFo7Fndcb1kF5wPJpc316vCJhhikedYnVysMh3Sc7Ocw==
+
 libpq@^1.7.0:
   version "1.8.9"
   resolved "https://registry.yarnpkg.com/libpq/-/libpq-1.8.9.tgz#6e0c6eecb176f6656ad092d67cc0131980cba897"


### PR DESCRIPTION
This PR fixes [IPCT1-X] at https://impactmarket.atlassian.net/browse/IPCT1-X

## Changes
Changed /communitites.
Now, this endpoint receives an optional authentication. 
- if receive an ambassador token, returns only communities related to this ambassador.
- if receive an ambassador token, and the `status: pending`, return pending communities in the same country as the ambassador. 

## Tests
new tests added