### PR TITLE
fix list communities (v2)

### DIFF
--- a/packages/api/src/controllers/v2/community/list.ts
+++ b/packages/api/src/controllers/v2/community/list.ts
@@ -1,6 +1,5 @@
 import { services } from '@impactmarket/core';
-import { Response } from 'express';
-import { RequestWithUser } from 'middlewares/core';
+import { Response, Request } from 'express';
 
 import { standardResponse } from '../../../utils/api';
 
@@ -10,9 +9,9 @@ class CommunityController {
         this.communityService = new services.ubi.CommunityListService();
     }
 
-    list = (req: RequestWithUser, res: Response) => {
+    list = (req: Request, res: Response) => {
         this.communityService
-            .list(req.query, req.user?.address)
+            .list(req.query)
             .then((r) => standardResponse(res, 200, true, r))
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));
     };

--- a/packages/api/src/routes/v2/community/list.ts
+++ b/packages/api/src/routes/v2/community/list.ts
@@ -71,9 +71,15 @@ export default (route: Router): void => {
      *           type: number
      *         required: false
      *         description: longitude used for nearest location
+     *       - in: query
+     *         name: ambassadorAddress
+     *         schema:
+     *           type: string
+     *         required: false
+     *         description: filter communities by ambassadors
      *     responses:
      *       "200":
      *         description: OK
      */
-    route.get('/:query?', optionalAuthentication, controller.list);
+    route.get('/:query?', controller.list);
 };

--- a/packages/core/src/services/ubi/community/list.ts
+++ b/packages/core/src/services/ubi/community/list.ts
@@ -32,8 +32,8 @@ export class CommunityListService {
             lng?: string;
             fields?: string;
             status?: 'valid' | 'pending';
+            ambassadorAddress?: string;
         },
-        ambassadorAddress?: string
     ): Promise<{ count: number; rows: CommunityAttributes[] }> {
         let extendedWhere: WhereOptions<CommunityAttributes> = {};
         const orderOption: OrderItem[] = [];
@@ -91,7 +91,7 @@ export class CommunityListService {
 
         if (query.status === 'pending') {
             const communityProposals = await this._getOpenProposals();
-            if (ambassadorAddress) {
+            if (query.ambassadorAddress) {
                 const ambassador = (await models.appUser.findOne({
                     attributes: [],
                     include: [
@@ -102,7 +102,7 @@ export class CommunityListService {
                         },
                     ],
                     where: {
-                        address: ambassadorAddress,
+                        address: query.ambassadorAddress,
                     },
                 })) as any;
                 const phone = ambassador?.trust[0]?.phone;
@@ -126,10 +126,10 @@ export class CommunityListService {
                 },
             };
         } else {
-            if (ambassadorAddress) {
+            if (query.ambassadorAddress) {
                 extendedWhere = {
                     ...extendedWhere,
-                    ambassadorAddress,
+                    ambassadorAddress: query.ambassadorAddress,
                 };
             }
         }

--- a/packages/core/tests/integration/v2/community.test.ts
+++ b/packages/core/tests/integration/v2/community.test.ts
@@ -1677,7 +1677,7 @@ describe('community service v2', () => {
                 returnClaimedSubgraph.returns([]);
                 returnCommunityEntities.returns([]);
 
-                const result = await communityListService.list({ status: 'pending' }, ambassadors[1].address);
+                const result = await communityListService.list({ status: 'pending', ambassadorAddress: ambassadors[1].address });
 
                 expect(result.count).to.be.equal(1);
                 expect(result.rows[0].id).to.be.equal(communities[0].id);
@@ -1738,7 +1738,7 @@ describe('community service v2', () => {
                 returnClaimedSubgraph.returns([]);
                 returnCommunityEntities.returns([]);
 
-                const result = await communityListService.list({}, ambassadors[0].address);
+                const result = await communityListService.list({ ambassadorAddress: ambassadors[0].address });
 
                 expect(result.count).to.be.equal(1);
                 expect(result.rows[0].id).to.be.equal(communities[0].id);


### PR DESCRIPTION
no task related.

## Changes
Now, to list communities by ambassadors, the user should send the `ambassadorAddress` as a query parameter.

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->