### PR TITLE
[BUGFIX] - list communities

### DIFF
--- a/packages/core/src/services/ubi/community/list.ts
+++ b/packages/core/src/services/ubi/community/list.ts
@@ -526,7 +526,10 @@ export class CommunityListService {
                         query.offset
                             ? parseInt(query.offset, 10)
                             : config.defaultOffset
-                    },`,
+                    },
+                    where: {
+                        state: 0
+                    }`,
                 `id, ${orderBy}`
             );
         }


### PR DESCRIPTION
no task.

## Changes
include a `where` in the graph query to return only active communities

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->