### PR TITLE
get ambassador from TheGraph

### DIFF
--- a/packages/core/src/subgraph/queries/community.ts
+++ b/packages/core/src/subgraph/queries/community.ts
@@ -174,3 +174,30 @@ export const communityEntities = async (where: string, fields: string) => {
         throw new Error(error);
     }
 };
+
+export const getCommunityAmbassador = async (community: string) => {
+    try {
+        const query = gql`
+            {
+                ambassadorEntities(
+                    where:{
+                        communities_contains: ["${community}"]
+                        status: 0
+                    }
+                ) {
+                    id
+                    since
+                }
+            }
+        `;
+
+        const queryResult = await clientCouncil.query({
+            query,
+            fetchPolicy: 'no-cache',
+        });
+
+        return queryResult.data?.ambassadorEntities[0];
+    } catch (error) {
+        throw new Error(error);
+    }
+};


### PR DESCRIPTION
This PR fixes #339 

## Changes
update `getAmbassador` service, to get from database only if the community is pending, otherwise get from TheGraph

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->