### PR TITLE
fix list extended communities

### DIFF
--- a/packages/core/src/services/ubi/community.ts
+++ b/packages/core/src/services/ubi/community.ts
@@ -2384,6 +2384,13 @@ export default class CommunityService {
         let contractAddress: string[] = [];
         let localResult: any[] = [];
         let subgraphResult: any[] = [];
+        const limit = query.limit
+            ? parseInt(query.limit, 10)
+            : config.defaultLimit;
+        const offset = query.offset
+            ? parseInt(query.offset, 10)
+            : config.defaultOffset;
+
         if (Object.keys(extendedWhere).length > 0) {
             localResult = await models.community.findAll({
                 attributes: ['id', 'contractAddress'],
@@ -2407,16 +2414,8 @@ export default class CommunityService {
                         orderDirection: ${
                             orderType ? orderType.toLocaleLowerCase() : 'desc'
                         },
-                        first: ${
-                            query.limit
-                                ? parseInt(query.limit, 10)
-                                : config.defaultLimit
-                        },
-                        skip: ${
-                            query.offset
-                                ? parseInt(query.offset, 10)
-                                : config.defaultOffset
-                        },
+                        first: ${limit > 1000 ? 1000 : limit},
+                        skip: ${offset},
                         where: { id_in: [${contractAddress.map(
                             (el) => `"${el.toLocaleLowerCase()}"`
                         )}]}`,
@@ -2428,16 +2427,8 @@ export default class CommunityService {
                     orderDirection: ${
                         orderType ? orderType.toLocaleLowerCase() : 'desc'
                     },
-                    first: ${
-                        query.limit
-                            ? parseInt(query.limit, 10)
-                            : config.defaultLimit
-                    },
-                    skip: ${
-                        query.offset
-                            ? parseInt(query.offset, 10)
-                            : config.defaultOffset
-                    },
+                    first: ${limit > 1000 ? 1000 : limit},
+                    skip: ${offset},
                     where: {
                         state: 0
                     }`,


### PR DESCRIPTION
no task.

## Changes
fix listing extended communities.
the `limit` option should be between 0 and 1000.
if the front end passes a bigger number, we will set it up as 1000.

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->