### PR TITLE
[357] - refactor filter managers/beneficiaries by state

### DIFF
--- a/packages/api/src/controllers/v2/community/details.ts
+++ b/packages/api/src/controllers/v2/community/details.ts
@@ -35,7 +35,7 @@ class CommunityController {
                 parseInt(offset, 10),
                 parseInt(limit, 10),
                 {
-                    state,
+                    state: state ? parseInt(state) : undefined,
                 },
                 search !== undefined && typeof search === 'string'
                     ? search
@@ -86,7 +86,7 @@ class CommunityController {
                 parseInt(offset, 10),
                 parseInt(limit, 10),
                 {
-                    state,
+                    state: state ? parseInt(state) : undefined,
                     suspect: suspect ? suspect === 'true' : undefined,
                     inactivity: inactivity ? inactivity === 'true' : undefined,
                     unidentified: unidentified

--- a/packages/api/src/routes/v2/community/details.ts
+++ b/packages/api/src/routes/v2/community/details.ts
@@ -76,9 +76,9 @@ export default (route: Router): void => {
      *         name: state
      *         schema:
      *           type: string
-     *           enum: [active, removed]
+     *           enum: [0, 1]
      *         required: false
-     *         description: manager state
+     *         description: manager state (0 - active, 1 - removed)
      *       - in: query
      *         name: offset
      *         schema:
@@ -184,9 +184,9 @@ export default (route: Router): void => {
      *         name: state
      *         schema:
      *           type: string
-     *           enum: [active, removed]
+     *           enum: [0, 1, 2]
      *         required: false
-     *         description: beneficiary state
+     *         description: beneficiary state (0 - active, 1 - removed, 2 - locked)
      *       - in: query
      *         name: offset
      *         schema:

--- a/packages/core/src/services/endpoints.ts
+++ b/packages/core/src/services/endpoints.ts
@@ -278,7 +278,7 @@ export type IBeneficiaryActivities = {
 };
 
 export type BeneficiaryFilterType = {
-    state?: string;
+    state?: number;
     active?: boolean;
     suspect?: boolean;
     inactivity?: boolean;

--- a/packages/core/src/services/ubi/community.ts
+++ b/packages/core/src/services/ubi/community.ts
@@ -1183,11 +1183,11 @@ export default class CommunityService {
 
         const activeBeneficiaries = await countBeneficiaries(
             community!.contractAddress!,
-            'active'
+            0
         );
         const removedBeneficiaries = await countBeneficiaries(
             community!.contractAddress!,
-            'removed'
+            1
         );
 
         const communityManagerActivity = await this.manager.count({

--- a/packages/core/src/subgraph/queries/beneficiary.ts
+++ b/packages/core/src/subgraph/queries/beneficiary.ts
@@ -176,7 +176,7 @@ export const getBeneficiaryCommunity = async (
 
 export const countBeneficiaries = async (
     community: string,
-    state: string
+    state?: number
 ): Promise<number> => {
     try {
         const query = gql`
@@ -194,15 +194,21 @@ export const countBeneficiaries = async (
             fetchPolicy: 'no-cache',
         });
 
-        if (state === 'active') {
-            return queryResult.data.communityEntity?.beneficiaries;
-        } else if (state === 'removed') {
-            return queryResult.data.communityEntity?.removedBeneficiaries;
-        } else {
-            return (
-                queryResult.data.communityEntity?.beneficiaries +
-                queryResult.data.communityEntity?.removedBeneficiaries
-            );
+        switch (state) {
+            case 0:
+                return queryResult.data.communityEntity?.beneficiaries;
+            case 1:
+                return queryResult.data.communityEntity?.removedBeneficiaries;
+            case 2:
+                return queryResult.data.communityEntity?.lockedBeneficiaries;
+            default:
+                return (
+                    queryResult.data.communityEntity?.beneficiaries +
+                    queryResult.data.communityEntity?.removedBeneficiaries +
+                    (queryResult.data.communityEntity?.lockedBeneficiaries
+                        ? queryResult.data.communityEntity?.lockedBeneficiaries
+                        : 0) // TODO: remove "if" when TheGraph updates
+                );
         }
     } catch (error) {
         throw new Error(error);

--- a/packages/core/src/subgraph/queries/manager.ts
+++ b/packages/core/src/subgraph/queries/manager.ts
@@ -56,7 +56,7 @@ export const getCommunityManagers = async (
 
 export const countManagers = async (
     community: string,
-    state: string
+    state?: number
 ): Promise<number> => {
     try {
         const query = gql`
@@ -74,9 +74,9 @@ export const countManagers = async (
             fetchPolicy: 'no-cache',
         });
 
-        if (state === 'active') {
+        if (state === 0) {
             return queryResult.data.communityEntity.managers;
-        } else if (state === 'removed') {
+        } else if (state === 1) {
             return queryResult.data.communityEntity.removedManagers;
         } else {
             return (


### PR DESCRIPTION
This PR fixes #357 

## Changes
Refactor filter managers/beneficiaries by state.
Instead of using `active`, `removed` and `locked`, use `0` (active), `1` (removed) and `2` (locked).
The endpoint response was changed too.

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->