### PR TITLE
[245] - filter communities by requestedByAddress

### DIFF
--- a/packages/api/src/routes/v2/community/list.ts
+++ b/packages/api/src/routes/v2/community/list.ts
@@ -23,11 +23,11 @@ export default (route: Router): void => {
      *         required: false
      *         description: communities list order (bigger by default)
      *       - in: query
-     *         name: name
+     *         name: search
      *         schema:
      *           type: string
      *         required: false
-     *         description: communities name to search
+     *         description: search by name or requestByAddress
      *       - in: query
      *         name: country
      *         schema:

--- a/packages/core/src/services/ubi/community/details.ts
+++ b/packages/core/src/services/ubi/community/details.ts
@@ -25,7 +25,7 @@ import {
 import { getUserRoles } from '../../../subgraph/queries/user';
 import { BaseError } from '../../../utils/baseError';
 import { Logger } from '../../../utils/logger';
-import { isAddress } from '../../../utils/util';
+import { isAddress, getSearchInput } from '../../../utils/util';
 import { IListBeneficiary, BeneficiaryFilterType } from '../../endpoints';
 import { CommunityContentStorage } from '../../storage';
 
@@ -291,11 +291,13 @@ export class CommunityDetailsService {
         }
 
         if (searchInput) {
-            const input = this.getSearchInput(searchInput);
+            const input = getSearchInput(searchInput);
             if (input.address) {
                 addresses.push(input.address);
-            } else if (input.appUserFilter) {
-                appUserFilter = input.appUserFilter;
+            } else if (input.name) {
+                appUserFilter = literal(
+                    `concat("firstName", ' ', "lastName") ILIKE '%${input.name}%'`
+                );
             }
         }
 
@@ -508,11 +510,13 @@ export class CommunityDetailsService {
         }
 
         if (searchInput) {
-            const input = this.getSearchInput(searchInput);
+            const input = getSearchInput(searchInput);
             if (input.address) {
                 addresses.push(input.address);
-            } else if (input.appUserFilter) {
-                appUserFilter = input.appUserFilter;
+            } else if (input.name) {
+                appUserFilter = literal(
+                    `concat("firstName", ' ', "lastName") ILIKE '%${input.name}%'`
+                );
             }
         }
 
@@ -833,25 +837,5 @@ export class CommunityDetailsService {
         if (!result) return null;
 
         return result.toJSON();
-    }
-
-    private getSearchInput(searchInput: string) {
-        if (isAddress(searchInput)) {
-            return {
-                address: ethers.utils.getAddress(searchInput),
-            };
-        } else if (
-            searchInput.toLowerCase().indexOf('drop') === -1 &&
-            searchInput.toLowerCase().indexOf('delete') === -1 &&
-            searchInput.toLowerCase().indexOf('update') === -1
-        ) {
-            return {
-                appUserFilter: literal(
-                    `concat("firstName", ' ', "lastName") ILIKE '%${searchInput}%'`
-                ),
-            };
-        } else {
-            throw new BaseError('INVALID_SEARCH', 'Not valid search!');
-        }
     }
 }

--- a/packages/core/src/services/ubi/community/list.ts
+++ b/packages/core/src/services/ubi/community/list.ts
@@ -23,7 +23,6 @@ export class CommunityListService {
     public async list(query: {
         orderBy?: string;
         filter?: string;
-        name?: string; // TODO: remove
         search?: string;
         country?: string;
         excludeCountry?: string;
@@ -79,16 +78,6 @@ export class CommunityListService {
             extendedWhere = {
                 ...extendedWhere,
                 id: { [Op.in]: featuredIds },
-            };
-        }
-
-        // TODO: remove
-        if (query.name) {
-            extendedWhere = {
-                ...extendedWhere,
-                name: {
-                    [Op.iLike]: `%${query.name}%`,
-                },
             };
         }
 

--- a/packages/core/src/services/ubi/community/list.ts
+++ b/packages/core/src/services/ubi/community/list.ts
@@ -86,7 +86,7 @@ export class CommunityListService {
             if (input.address) {
                 extendedWhere = {
                     ...extendedWhere,
-                    requestByAddress: query.search,
+                    requestByAddress: input.address,
                 };
             } else if (input.name) {
                 extendedWhere = {

--- a/packages/core/src/services/ubi/community/list.ts
+++ b/packages/core/src/services/ubi/community/list.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../subgraph/queries/community';
 import { BaseError } from '../../../utils/baseError';
 import { fetchData } from '../../../utils/dataFetching';
+import { getSearchInput } from '../../../utils/util';
 import { CommunityDetailsService } from './details';
 
 export class CommunityListService {
@@ -22,7 +23,8 @@ export class CommunityListService {
     public async list(query: {
         orderBy?: string;
         filter?: string;
-        name?: string;
+        name?: string; // TODO: remove
+        search?: string;
         country?: string;
         excludeCountry?: string;
         extended?: string;
@@ -80,6 +82,7 @@ export class CommunityListService {
             };
         }
 
+        // TODO: remove
         if (query.name) {
             extendedWhere = {
                 ...extendedWhere,
@@ -87,6 +90,23 @@ export class CommunityListService {
                     [Op.iLike]: `%${query.name}%`,
                 },
             };
+        }
+
+        if (query.search) {
+            const input = getSearchInput(query.search);
+            if (input.address) {
+                extendedWhere = {
+                    ...extendedWhere,
+                    requestByAddress: query.search,
+                };
+            } else if (input.name) {
+                extendedWhere = {
+                    ...extendedWhere,
+                    name: {
+                        [Op.iLike]: `%${input.name}%`,
+                    },
+                };
+            }
         }
 
         if (query.country) {

--- a/packages/core/src/utils/util.ts
+++ b/packages/core/src/utils/util.ts
@@ -1,6 +1,6 @@
+import { getAddress } from '@ethersproject/address';
 import axios from 'axios';
 import BigNumber from 'bignumber.js';
-import { ethers } from 'ethers';
 import { Expo, ExpoPushMessage, ExpoPushTicket } from 'expo-server-sdk';
 
 import config from '../config';
@@ -281,7 +281,7 @@ export function createThumbnailUrl(
 export const getSearchInput = (searchInput: string) => {
     if (isAddress(searchInput)) {
         return {
-            address: ethers.utils.getAddress(searchInput),
+            address: getAddress(searchInput),
         };
     } else if (
         searchInput.toLowerCase().indexOf('drop') === -1 &&

--- a/packages/core/src/utils/util.ts
+++ b/packages/core/src/utils/util.ts
@@ -1,11 +1,13 @@
 import axios from 'axios';
 import BigNumber from 'bignumber.js';
+import { ethers } from 'ethers';
 import { Expo, ExpoPushMessage, ExpoPushTicket } from 'expo-server-sdk';
 
 import config from '../config';
 import { Community } from '../database/models/ubi/community';
 import { AppMediaThumbnail } from '../interfaces/app/appMediaThumbnail';
 import UserService from '../services/app/user';
+import { BaseError } from './baseError';
 import { Logger } from './logger';
 
 BigNumber.config({ EXPONENTIAL_AT: [-7, 30] });
@@ -275,3 +277,21 @@ export function createThumbnailUrl(
 
     return avatar;
 }
+
+export const getSearchInput = (searchInput: string) => {
+    if (isAddress(searchInput)) {
+        return {
+            address: ethers.utils.getAddress(searchInput),
+        };
+    } else if (
+        searchInput.toLowerCase().indexOf('drop') === -1 &&
+        searchInput.toLowerCase().indexOf('delete') === -1 &&
+        searchInput.toLowerCase().indexOf('update') === -1
+    ) {
+        return {
+            name: searchInput,
+        };
+    } else {
+        throw new BaseError('INVALID_SEARCH', 'Not valid search!');
+    }
+};

--- a/packages/core/tests/integration/v2/community.test.ts
+++ b/packages/core/tests/integration/v2/community.test.ts
@@ -110,7 +110,7 @@ describe('community service v2', () => {
                 ]);
 
                 const result = await communityListService.list({
-                    name: communities[0].name,
+                    search: communities[0].name,
                 });
 
                 expect(result.rows[0]).to.include({
@@ -154,7 +154,7 @@ describe('community service v2', () => {
                 ]);
 
                 const result = await communityListService.list({
-                    name: communities[0].name.slice(
+                    search: communities[0].name.slice(
                         0,
                         communities[0].name.length / 2
                     ),
@@ -201,7 +201,7 @@ describe('community service v2', () => {
                 ]);
 
                 const result = await communityListService.list({
-                    name: communities[0].name.slice(
+                    search: communities[0].name.slice(
                         communities[0].name.length / 2,
                         communities[0].name.length - 1
                     ),
@@ -248,7 +248,7 @@ describe('community service v2', () => {
                 ]);
 
                 const result = await communityListService.list({
-                    name: communities[0].name.toUpperCase(),
+                    search: communities[0].name.toUpperCase(),
                 });
 
                 expect(result.rows[0]).to.include({
@@ -323,7 +323,7 @@ describe('community service v2', () => {
                 );
 
                 const result = await communityListService.list({
-                    name: 'oreo',
+                    search: 'oreo',
                 });
 
                 expect(result.count).to.be.equal(2);
@@ -595,6 +595,50 @@ describe('community service v2', () => {
                         id: communities[3].id,
                     },
                 ]);
+            });
+        });
+
+        it('by requestedByAddress', async () => {
+            const communities = await CommunityFactory([
+                {
+                    requestByAddress: users[0].address,
+                    started: new Date(),
+                    status: 'valid',
+                    visibility: 'public',
+                    contract: {
+                        baseInterval: 60 * 60 * 24,
+                        claimAmount: 1,
+                        communityId: 0,
+                        incrementInterval: 5 * 60,
+                        maxClaim: 450,
+                    },
+                    hasAddress: true,
+                },
+            ]);
+
+            returnCommunityEntities.returns([
+                {
+                    id: communities[0].contractAddress,
+                    beneficiaries: 0,
+                },
+            ]);
+
+            returnClaimedSubgraph.returns([
+                {
+                    id: communities[0].contractAddress,
+                    claimed: 0,
+                },
+            ]);
+
+            const result = await communityListService.list({
+                search: users[0].address,
+            });
+
+            expect(result.rows[0]).to.include({
+                id: communities[0].id,
+                name: communities[0].name,
+                country: communities[0].country,
+                requestByAddress: users[0].address,
             });
         });
 

--- a/packages/core/tests/integration/v2/community.test.ts
+++ b/packages/core/tests/integration/v2/community.test.ts
@@ -601,7 +601,7 @@ describe('community service v2', () => {
         it('by requestedByAddress', async () => {
             const communities = await CommunityFactory([
                 {
-                    requestByAddress: users[0].address,
+                    requestByAddress: users[1].address,
                     started: new Date(),
                     status: 'valid',
                     visibility: 'public',
@@ -631,14 +631,14 @@ describe('community service v2', () => {
             ]);
 
             const result = await communityListService.list({
-                search: users[0].address,
+                search: users[1].address,
             });
 
             expect(result.rows[0]).to.include({
                 id: communities[0].id,
                 name: communities[0].name,
                 country: communities[0].country,
-                requestByAddress: users[0].address,
+                requestByAddress: users[1].address,
             });
         });
 


### PR DESCRIPTION
This PR fixes #245

## Changes
On community requests, filter by the user requesting ("requestedByAddress")

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->