### PR TITLE
set lowercase address in community list

### DIFF
--- a/packages/core/src/utils/util.ts
+++ b/packages/core/src/utils/util.ts
@@ -281,7 +281,7 @@ export function createThumbnailUrl(
 export const getSearchInput = (searchInput: string) => {
     if (isAddress(searchInput)) {
         return {
-            address: getAddress(searchInput),
+            address: getAddress(searchInput.toLocaleLowerCase()),
         };
     } else if (
         searchInput.toLowerCase().indexOf('drop') === -1 &&


### PR DESCRIPTION
no task.

## Changes
The lib `ether.utils.getAddress` receive an address, but this address needs to be formatted or in a lowercase, so before using this function we are setting a lowercase address.

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->