### PR TITLE
[440] - register wallet notifications

### DIFF
--- a/packages/api/src/controllers/v2/user.ts
+++ b/packages/api/src/controllers/v2/user.ts
@@ -345,7 +345,7 @@ class UserController {
         }
 
         this.userService
-            .getUnreadNotifications(req.user.userId)
+            .getUnreadNotifications(req.user.userId, req.query)
             .then((r) => standardResponse(res, 200, true, r))
             .catch((e) =>
                 standardResponse(res, 400, false, '', { error: e.message })

--- a/packages/api/src/routes/v2/user.ts
+++ b/packages/api/src/routes/v2/user.ts
@@ -386,6 +386,17 @@ export default (app: Router): void => {
      *     tags:
      *       - "users"
      *     summary: Get the number of unread notifications from a user
+     *     parameters:
+     *       - in: query
+     *         name: isWebApp
+     *         schema:
+     *           type: boolean
+     *         required: false
+     *       - in: query
+     *         name: isWallet
+     *         schema:
+     *           type: boolean
+     *         required: false
      *     responses:
      *       "200":
      *          description: OK
@@ -404,7 +415,7 @@ export default (app: Router): void => {
      *       - "write:modify":
      */
     route.get(
-        '/notifications/unread',
+        '/notifications/unread/:query?',
         authenticateToken,
         userController.getUnreadNotifications
     );
@@ -430,6 +441,16 @@ export default (app: Router): void => {
      *           type: integer
      *         required: false
      *         description: limit used for community pagination (default 10)
+     *       - in: query
+     *         name: isWebApp
+     *         schema:
+     *           type: boolean
+     *         required: false
+     *       - in: query
+     *         name: isWallet
+     *         schema:
+     *           type: boolean
+     *         required: false
      *     responses:
      *       "200":
      *          description: OK

--- a/packages/core/src/database/migrations/z1631138691-create-notification.js
+++ b/packages/core/src/database/migrations/z1631138691-create-notification.js
@@ -30,6 +30,16 @@ module.exports = {
                 type: Sequelize.BOOLEAN,
                 defaultValue: false,
             },
+            isWallet: {
+                type: Sequelize.BOOLEAN,
+                allowNull: false,
+                defaultValue: false,
+            },
+            isWebApp: {
+                type: Sequelize.BOOLEAN,
+                allowNull: false,
+                defaultValue: true,
+            },
             createdAt: {
                 type: Sequelize.DATE,
                 allowNull: false,

--- a/packages/core/src/database/migrations/z1671043272-update-appNotification.js
+++ b/packages/core/src/database/migrations/z1671043272-update-appNotification.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+        await queryInterface.addColumn('app_notification', 'isWallet', {
+            type: Sequelize.BOOLEAN,
+            allowNull: false,
+            default: false,
+        });
+
+        await queryInterface.addColumn('app_notification', 'isWebApp', {
+            type: Sequelize.BOOLEAN,
+            allowNull: false,
+            default: true,
+        });
+    },
+
+    down(queryInterface, Sequelize) {},
+};

--- a/packages/core/src/database/migrations/z1671043272-update-appNotification.js
+++ b/packages/core/src/database/migrations/z1671043272-update-appNotification.js
@@ -9,13 +9,13 @@ module.exports = {
         await queryInterface.addColumn('app_notification', 'isWallet', {
             type: Sequelize.BOOLEAN,
             allowNull: false,
-            default: false,
+            defaultValue: false,
         });
 
         await queryInterface.addColumn('app_notification', 'isWebApp', {
             type: Sequelize.BOOLEAN,
             allowNull: false,
-            default: true,
+            defaultValue: true,
         });
     },
 

--- a/packages/core/src/database/models/app/appNotification.ts
+++ b/packages/core/src/database/models/app/appNotification.ts
@@ -54,10 +54,12 @@ export function initializeAppNotification(sequelize: Sequelize): void {
             isWallet: {
                 type: DataTypes.BOOLEAN,
                 allowNull: false,
+                defaultValue: false,
             },
             isWebApp: {
                 type: DataTypes.BOOLEAN,
                 allowNull: false,
+                defaultValue: true,
             },
             createdAt: {
                 type: DataTypes.DATE,

--- a/packages/core/src/database/models/app/appNotification.ts
+++ b/packages/core/src/database/models/app/appNotification.ts
@@ -14,6 +14,8 @@ export class AppNotificationModel extends Model<
     public type!: number;
     public params!: object;
     public read!: boolean;
+    public isWallet!: boolean;
+    public isWebApp!: boolean;
 
     // timestamps!
     public readonly createdAt!: Date;
@@ -48,6 +50,14 @@ export function initializeAppNotification(sequelize: Sequelize): void {
                 type: DataTypes.BOOLEAN,
                 allowNull: false,
                 defaultValue: false,
+            },
+            isWallet: {
+                type: DataTypes.BOOLEAN,
+                allowNull: false,
+            },
+            isWebApp: {
+                type: DataTypes.BOOLEAN,
+                allowNull: false,
             },
             createdAt: {
                 type: DataTypes.DATE,

--- a/packages/core/src/interfaces/app/appNotification.ts
+++ b/packages/core/src/interfaces/app/appNotification.ts
@@ -45,6 +45,8 @@ export interface AppNotification {
     type: number;
     params: object;
     read: boolean;
+    isWallet: boolean;
+    isWebApp: boolean;
 
     //timestamp
     createdAt: Date;
@@ -55,4 +57,6 @@ export interface AppNotificationCreation {
     type: number;
     params?: object;
     read?: boolean;
+    isWallet?: boolean;
+    isWebApp?: boolean;
 }

--- a/packages/core/src/services/app/user/index.ts
+++ b/packages/core/src/services/app/user/index.ts
@@ -398,6 +398,8 @@ export default class UserService {
         query: {
             offset?: string;
             limit?: string;
+            isWallet?: string;
+            isWebApp?: string;
         },
         userId: number
     ): Promise<{
@@ -407,6 +409,8 @@ export default class UserService {
         const notifications = await models.appNotification.findAndCountAll({
             where: {
                 userId,
+                isWebApp: query.isWebApp === 'true',
+                isWallet: query.isWallet === 'true',
             },
             offset: query.offset
                 ? parseInt(query.offset, 10)
@@ -449,11 +453,19 @@ export default class UserService {
         return true;
     }
 
-    public async getUnreadNotifications(userId: number): Promise<number> {
+    public async getUnreadNotifications(
+        userId: number,
+        query: {
+            isWallet?: string;
+            isWebApp?: string;
+        }
+    ): Promise<number> {
         return models.appNotification.count({
             where: {
                 userId,
                 read: false,
+                isWebApp: query.isWebApp === 'true',
+                isWallet: query.isWallet === 'true',
             },
         });
     }

--- a/packages/core/tests/integration/v2/user.test.ts
+++ b/packages/core/tests/integration/v2/user.test.ts
@@ -649,7 +649,10 @@ describe('user service v2', () => {
                 userId: user.id,
             });
             const notifications = await userService.getUnreadNotifications(
-                user.id
+                user.id,
+                {
+                    isWebApp: 'true',
+                }
             );
 
             expect(notifications).to.be.eq(1);

--- a/packages/core/tests/integration/v2/user.test.ts
+++ b/packages/core/tests/integration/v2/user.test.ts
@@ -605,7 +605,9 @@ describe('user service v2', () => {
             });
 
             const notifications = await userService.getNotifications(
-                {},
+                {
+                    isWebApp: 'true',
+                },
                 user.id
             );
             expect(notifications).to.be.not.null;
@@ -622,7 +624,9 @@ describe('user service v2', () => {
                 userId: user.id,
             });
             const notifications = await userService.getNotifications(
-                {},
+                {
+                    isWebApp: 'true',
+                },
                 user.id
             );
 


### PR DESCRIPTION
This PR fixes #440 

## Changes
Add `isWallet` and `isWebApp` in app_notification table and in notifications endpoints (GET)

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->