### PR TITLE
get global data from microcredit subgraph

### DIFF
--- a/packages/api/src/controllers/v2/microcredit.ts
+++ b/packages/api/src/controllers/v2/microcredit.ts
@@ -1,0 +1,16 @@
+import { services } from '@impactmarket/core';
+import { Request, Response } from 'express';
+import { standardResponse } from '../../utils/api';
+
+class MicrocreditController {
+    microcreditService = new services.MicrocreditService();
+
+    getGlobalData = async (req: Request, res: Response): Promise<void> => {
+        this.microcreditService
+            .getGlobalData()
+            .then((r) => standardResponse(res, 200, true, r))
+            .catch((e) => standardResponse(res, 400, false, '', { error: e }));
+    };
+}
+
+export default MicrocreditController;

--- a/packages/api/src/routes/v2/index.ts
+++ b/packages/api/src/routes/v2/index.ts
@@ -8,6 +8,7 @@ import global from './global';
 import learnAndEarn from './learnAndEarn';
 import story from './story';
 import user from './user';
+import microcredit from './microcredit';
 
 export default (): Router => {
     const app = Router();
@@ -19,6 +20,7 @@ export default (): Router => {
     learnAndEarn(app);
     global(app);
     attestation(app);
+    microcredit(app);
 
     return app;
 };

--- a/packages/api/src/routes/v2/microcredit.ts
+++ b/packages/api/src/routes/v2/microcredit.ts
@@ -12,7 +12,7 @@ export default (app: Router): void => {
     /**
      * @swagger
      *
-     * /microcredit/global-data:
+     * /microcredit/global:
      *   get:
      *     tags:
      *       - "microcredit"

--- a/packages/api/src/routes/v2/microcredit.ts
+++ b/packages/api/src/routes/v2/microcredit.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+
+import MicrocreditController from '../../controllers/v2/microcredit';
+import { cache } from '../../middlewares/cache-redis';
+import { cacheIntervals } from '../../utils/api';
+
+export default (app: Router): void => {
+    const microcreditController = new MicrocreditController();
+    const route = Router();
+    app.use('/microcredit', route);
+
+    /**
+     * @swagger
+     *
+     * /microcredit/global-data:
+     *   get:
+     *     tags:
+     *       - "microcredit"
+     *     summary: "Get Glboal Data"
+     *     responses:
+     *       "200":
+     *         description: OK
+     *     security:
+     *     - api_auth:
+     *       - "write:modify":
+     */
+    route.get(
+        '/global',
+        cache(cacheIntervals.oneHour),
+        microcreditController.getGlobalData
+    );
+};

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -254,6 +254,7 @@ export default {
 
     subgraphUrl: validatedEnv.SUBGRAPH_URL,
     councilSubgraphUrl: validatedEnv.COUNCIL_SUBGRAPH_URL,
+    microcreditSubgraphUrl: validatedEnv.MICROCREDIT_SUBGRAPH_URL,
     imageHandlerUrl: validatedEnv.IMAGE_HANDLER_URL,
     signatureExpiration: validatedEnv.SIGNATURE_EXPIRATION,
     learnAndEarnPrivateKey: validatedEnv.LEARN_AND_EARN_PRIVATE_KEY,

--- a/packages/core/src/config/validatenv.ts
+++ b/packages/core/src/config/validatenv.ts
@@ -113,6 +113,7 @@ function validateEnv() {
         AWS_LAMBDA: bool({ default: false }),
         SUBGRAPH_URL: str({ devDefault: onlyOnTestEnv('xyz') }),
         COUNCIL_SUBGRAPH_URL: str({ devDefault: onlyOnTestEnv('xyz') }),
+        MICROCREDIT_SUBGRAPH_URL: str({ devDefault: onlyOnTestEnv('xyz') }),
         IMAGE_HANDLER_URL: str({ devDefault: onlyOnTestEnv('xyz') }),
         SIGNATURE_EXPIRATION: num({ default: 15 }),
         LEARN_AND_EARN_PRIVATE_KEY: str({ devDefault: onlyOnTestEnv('xyz') }),

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -12,6 +12,7 @@ import ReachedAddressService from './reachedAddress';
 import * as storage from './storage';
 import StoryService from './story';
 import StoryServiceV2 from './story/index';
+import MicrocreditService from './microcredit';
 import * as ubi from './ubi';
 
 const learnAndEarn = {
@@ -34,4 +35,5 @@ export {
     StoryService,
     StoryServiceV2,
     learnAndEarn,
+    MicrocreditService,
 };

--- a/packages/core/src/services/microcredit/index.ts
+++ b/packages/core/src/services/microcredit/index.ts
@@ -1,0 +1,22 @@
+import { queries } from '../../subgraph';
+
+export default class MicrocreditService {
+    public getGlobalData = async (): Promise<any> => {
+        const subgraphData = await queries.microcredit.getGlobalData();
+
+        // TODO: calculate applications { totalApplications, inReview }
+
+        const estimatedMaturity = 0;   // (paid back in the past 3 months / 3 / current debt)
+        const avgBorrowedAmount = Math.round(subgraphData.totalBorrowed / subgraphData.activeBorrowers);
+        const apr = 0;  // (paid back past 7 months - borrowed past 7 months) / borrowed past 7 months / 7 * 12
+
+        return {
+            totalApplications: 0,
+            inReview: 0,
+            estimatedMaturity,
+            avgBorrowedAmount,
+            apr,
+            ...subgraphData,
+        }
+    }
+}

--- a/packages/core/src/subgraph/config.ts
+++ b/packages/core/src/subgraph/config.ts
@@ -16,6 +16,13 @@ const axiosCouncilSubgraph = axios.create({
     },
     timeout: 4000,
 });
+const axiosMicrocreditSubgraph = axios.create({
+    baseURL: config.microcreditSubgraphUrl,
+    headers: {
+        'content-type': 'application/json',
+    },
+    timeout: 4000,
+});
 axiosRetry(axiosSubgraph, {
     retries: 3,
     retryDelay: axiosRetry.exponentialDelay,
@@ -24,5 +31,9 @@ axiosRetry(axiosCouncilSubgraph, {
     retries: 3,
     retryDelay: axiosRetry.exponentialDelay,
 });
+axiosRetry(axiosMicrocreditSubgraph, {
+    retries: 3,
+    retryDelay: axiosRetry.exponentialDelay,
+});
 
-export { axiosSubgraph, axiosCouncilSubgraph };
+export { axiosSubgraph, axiosCouncilSubgraph, axiosMicrocreditSubgraph };

--- a/packages/core/src/subgraph/queries/index.ts
+++ b/packages/core/src/subgraph/queries/index.ts
@@ -1,5 +1,6 @@
 import * as beneficiary from './beneficiary';
 import * as community from './community';
 import * as ubi from './ubi';
+import * as microcredit from './microcredit';
 
-export { beneficiary, community, ubi };
+export { beneficiary, community, ubi, microcredit };

--- a/packages/core/src/subgraph/queries/microcredit.ts
+++ b/packages/core/src/subgraph/queries/microcredit.ts
@@ -1,0 +1,90 @@
+import { axiosMicrocreditSubgraph } from '../config';
+
+type Asset = {
+    id: string,
+    asset: string,
+    amount: string,
+}
+
+export const getGlobalData = async (): Promise<{
+    totalBorrowed: number,
+    currentDebt: number,
+    paidBack: number,
+    earnedInterest: number,
+    activeBorrowers: number,
+    totalDebitsRepaid: number,
+    liquidityAvailable: number,
+}> => {
+    try {
+        const graphqlQuery = {
+            operationName: 'microCredit',
+            query: `query microCredit {
+                microCredit(
+                    id: 0
+                ) {
+                    borrowed {
+                        id
+                        asset
+                        amount
+                    }
+                    debt {
+                        id
+                        asset
+                        amount
+                    }
+                    repaid {
+                        id
+                        asset
+                        amount
+                    }
+                    interest {
+                        id
+                        asset
+                        amount
+                    }
+                    borrowers
+                    repayments
+                    liquidity {
+                        id
+                        asset
+                        amount
+                    }
+                }
+            }`,
+        };
+
+        const response = await axiosMicrocreditSubgraph.post<
+            any,
+            {
+                data: {
+                    data: {
+                        microCredit: {
+                            borrowed: Asset[],
+                            debit: Asset[],
+                            repaid: Asset[],
+                            interest: Asset[],
+                            borrowers: number,
+                            repayments: number,
+                            liquidity: Asset[],
+                        };
+                    };
+                };
+            }
+        >('', graphqlQuery);
+
+        const microCredit = response.data?.data.microCredit;
+
+        return {
+            totalBorrowed: microCredit.borrowed && microCredit.borrowed.length ? parseFloat(microCredit.borrowed[0].amount) : 0,
+            currentDebt: microCredit.debit && microCredit.debit.length ? parseFloat(microCredit.debit[0].amount) : 0,
+            paidBack: microCredit.repaid && microCredit.repaid.length ? parseFloat(microCredit.repaid[0].amount) : 0,
+            earnedInterest: microCredit.interest && microCredit.interest.length ? parseFloat(microCredit.interest[0].amount) : 0,
+            activeBorrowers: microCredit.borrowers ? microCredit.borrowers : 0,
+            totalDebitsRepaid: microCredit.repayments ? microCredit.repayments : 0,
+            liquidityAvailable: microCredit.liquidity && microCredit.liquidity.length ? parseFloat(microCredit.liquidity[0].amount) : 0,
+        };
+
+    } catch (error) {
+        throw new Error(error);
+    }
+};


### PR DESCRIPTION
This PR fixes #545 

## Changes
endpoint to return the Microcredit global data.

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->