### PR TITLE
L&E - change lesson interval

### DIFF
--- a/packages/core/src/services/learnAndEarn/answer.ts
+++ b/packages/core/src/services/learnAndEarn/answer.ts
@@ -174,9 +174,33 @@ export async function answer(
     try {
         const daysAgo = new Date();
         daysAgo.setDate(daysAgo.getDate() - config.intervalBetweenLessons);
+        
+        const lessonRegistry = await models.learnAndEarnLesson.findOne({
+            attributes: ['levelId'],
+            where: {
+                id: lessonId,
+            },
+        });
+
+        if (!lessonRegistry) {
+            throw new BaseError(
+                'LESSON_NOT_FOUND',
+                'lesson not found for the given id'
+            );
+        }
 
         // check if already completed a lesson today
         const concludedLessons = await models.learnAndEarnUserLesson.count({
+            include: [
+                {
+                    model: models.learnAndEarnLesson,
+                    as: 'lesson',
+                    required: true,
+                    where: {
+                        levelId: lessonRegistry.levelId,
+                    },
+                },
+            ],
             where: {
                 completionDate: {
                     [Op.gte]: daysAgo.setHours(0, 0, 0, 0),

--- a/packages/core/src/services/learnAndEarn/list.ts
+++ b/packages/core/src/services/learnAndEarn/list.ts
@@ -215,6 +215,16 @@ export async function listLessons(userId: number, levelId: number) {
         const daysAgo = new Date();
         daysAgo.setDate(daysAgo.getDate() - config.intervalBetweenLessons);
         const completedToday = await models.learnAndEarnUserLesson.count({
+            include: [
+                {
+                    model: models.learnAndEarnLesson,
+                    as: 'lesson',
+                    required: true,
+                    where: {
+                        levelId,
+                    },
+                },
+            ],
             where: {
                 completionDate: {
                     [Op.gte]: daysAgo.setHours(0, 0, 0, 0),


### PR DESCRIPTION
No task.

## Changes
Update flag `completedToday` returned on list lessons, to be true only if the user already completed a lesson in the same level.
Thus allowing users to do lessons in parallel.

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->