### PR TITLE
only claimed loans + object instead of array

### DIFF
--- a/packages/core/src/services/microcredit/list.ts
+++ b/packages/core/src/services/microcredit/list.ts
@@ -30,11 +30,12 @@ export default class MicroCreditList {
                 claimed: number;
                 repayed: string;
                 lastRepayment: number;
-            }[];
+            };
         }[]
     > => {
         // get borrowers loans from subgraph
-        const borrowers = await getBorrowers(query);
+        // and return only the active loan (which is only one)
+        const borrowers = (await getBorrowers({ ...query, claimed: true })).map((b) => ({ ...b, loans: b.loans[0] }));
 
         // get borrowers profile from database
         const userProfile = await models.appUser.findAll({

--- a/packages/core/src/subgraph/queries/microcredit.ts
+++ b/packages/core/src/subgraph/queries/microcredit.ts
@@ -111,6 +111,7 @@ export const getBorrowers = async (query: {
     offset?: number;
     limit?: number;
     addedBy?: string;
+    claimed?: boolean;
 }): Promise<
     {
         id: string;
@@ -137,7 +138,9 @@ export const getBorrowers = async (query: {
                         addedBy: "${
                             query.addedBy ? query.addedBy.toLowerCase() : ''
                         }"
+                        ${query.claimed ? `claimed_not: null` : ''}
                     }
+                    ${query.claimed ? `orderBy: claimed orderDirection: desc` : ''}
                 ) {
                     amount
                     period


### PR DESCRIPTION
No issue linked.

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR changes the `/api/v2/microcredit/borrowers` to return a loan object instead of array. Borrowers can have only one active loan, thus can be an object.

```json
{
  "success": true,
  "data": [
    {
      "address": "0x06Ab969427A375C557bcE7Af5E7A4056A61bf6c8",
      "loans": {
        "amount": "3",
        "period": 15552000,
        "dailyInterest": "0.12",
        "claimed": 1680711892,
        "repayed": "3",
        "lastRepayment": 1680712047
      },
      "firstName": "First",
      "lastName": "Last",
      "avatarMediaPath": "avatar/1679321183923.png"
    }
  ]
}
```

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->

no new tests