### PR TITLE
verify balances (hot wallets and LeanAndEarn) + prevent multiple subscribers

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,8 +1,11 @@
 import 'module-alias/register';
-import { utils, config, database, subscriber } from '@impactmarket/core';
+import { utils, config, database } from '@impactmarket/core';
 import express from 'express';
 
 import serverLoader from './server';
+import { startSubscribers } from './loaders/subscriber';
+import { checkWalletBalances } from './loaders/checkWalletBalances';
+import { checkLearnAndEarnBalances } from './loaders/checkLearnAndEarnBalances';
 
 export async function startServer() {
     const app = express();
@@ -21,11 +24,12 @@ export async function startServer() {
     }
     utils.Logger.info('🗺️  Database loaded and connected');
 
-    await serverLoader(app);
+    serverLoader(app);
     utils.Logger.info('📡 Express server loaded');
 
-    subscriber.start();
-    utils.Logger.info('⏱️ Chain Subscriber starting');
+    startSubscribers();
+    checkWalletBalances();
+    checkLearnAndEarnBalances();
 
     return app.listen(config.port, () => {
         utils.Logger.info(`

--- a/packages/api/src/config/index.ts
+++ b/packages/api/src/config/index.ts
@@ -72,6 +72,7 @@ export default {
         dao: validatedEnv.DAO_CONTRACT_ADDRESS,
         ido: validatedEnv.IDO_CONTRACT_ADDRESS,
         treasury: validatedEnv.TREASURY_CONTRACT_ADDRESS,
+        learnAndEarn: validatedEnv.LEARN_AND_EARN_CONTRACT_ADDRESS,
     },
     DAOContractAddress: validatedEnv.DAO_CONTRACT_ADDRESS,
     communityAdminAddress: validatedEnv.COMMUNITY_ADMIN_ADDRESS,
@@ -272,4 +273,11 @@ export default {
         isMainnet: validatedEnv.CHAIN_IS_MAINNET,
         jsonRPCUrlCelo: validatedEnv.CHAIN_JSON_RPC_URL_CELO,
     },
+
+    /**
+     * Variables for hot wallets
+     * They are used in different sevices and we need to keep track if
+     * they have enough balance to perform the operations
+     */
+    hotWalletsCheckBalance: validatedEnv.HOT_WALLET_CHECK_BALANCE,
 };

--- a/packages/api/src/config/validatenv.ts
+++ b/packages/api/src/config/validatenv.ts
@@ -94,6 +94,7 @@ function validateEnv() {
         IMPACTLABS_CONTRACT_ADDRESS: str({ devDefault: onlyOnTestEnv('xyz') }),
         IDO_CONTRACT_ADDRESS: str({ devDefault: onlyOnTestEnv('xyz') }),
         TREASURY_CONTRACT_ADDRESS: str({ devDefault: onlyOnTestEnv('xyz') }),
+        LEARN_AND_EARN_CONTRACT_ADDRESS: str({ devDefault: onlyOnTestEnv('xyz') }),
         AWS_LAMBDA: bool({ default: false }),
         SUBGRAPH_URL: str({ devDefault: onlyOnTestEnv('xyz') }),
         // attestation service (ASv2)
@@ -109,6 +110,8 @@ function validateEnv() {
         // chain
         CHAIN_IS_MAINNET: bool({ devDefault: true }),
         CHAIN_JSON_RPC_URL_CELO: str({ devDefault: onlyOnTestEnv('xyz') }),
+        // hot wallets
+        HOT_WALLET_CHECK_BALANCE: str({ devDefault: onlyOnTestEnv('xyz') }),
     });
 }
 

--- a/packages/api/src/loaders/checkLearnAndEarnBalances.ts
+++ b/packages/api/src/loaders/checkLearnAndEarnBalances.ts
@@ -1,0 +1,62 @@
+import { Contract } from '@ethersproject/contracts';
+import { formatEther } from '@ethersproject/units';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import config from '../config';
+import { sendEmail } from '../services/email';
+import { database, utils } from '@impactmarket/core';
+
+const { models } = database;
+const LearnAndEarnAbi = [
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "name": "levels",
+        "outputs": [
+            {
+                "internalType": "contract IERC20Upgradeable",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "balance",
+                "type": "uint256"
+            },
+            {
+                "internalType": "enum ILearnAndEarn.LevelState",
+                "name": "state",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]
+
+// using ethers, verify the balance of each level on LearnAndEarn and if below X, send email to someone
+export async function checkLearnAndEarnBalances() {
+    utils.Logger.info('Running checkLearnAndEarnBalances...');
+    const provider = new JsonRpcProvider(config.jsonRpcUrl);
+    const learnAndEarn = new Contract(config.contractAddresses.learnAndEarn, LearnAndEarnAbi, provider);
+
+    const levels = await models.learnAndEarnLevel.findAll({ where: { isLive: true, active: true } });
+
+    for (let i = 0; i < levels.length; i++) {
+        const level = await learnAndEarn.levels(levels[i].id);
+        const balance = parseFloat(formatEther(level.balance));
+        // send email if balance is not enough for 100 users
+        if (balance < levels[i].totalReward * 100) {
+            sendEmail({
+                to: 'developers@impactmarket.com',
+                from: 'hello@impactmarket.com',
+                subject: `LearnAndEarn low balance`,
+                text: `LearnAndEarn balance for level ${levels[i].id} is ${balance}`
+            });
+        }
+    }
+}

--- a/packages/api/src/loaders/checkWalletBalances.ts
+++ b/packages/api/src/loaders/checkWalletBalances.ts
@@ -1,0 +1,37 @@
+import { Contract } from '@ethersproject/contracts';
+import { parseEther, formatEther } from '@ethersproject/units';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import config from '../config';
+import { sendEmail } from '../services/email';
+import { utils } from '@impactmarket/core';
+
+// using ethers, verify the balance of cusd (an erc20) on a given account
+// if below X, send email to someone
+export async function checkWalletBalances() {
+    utils.Logger.info('Running checkLearnAndEarnBalances...');
+    const accounts = config.hotWalletsCheckBalance.split(';');
+    const provider = new JsonRpcProvider(config.jsonRpcUrl);
+    const contract = new Contract(config.cUSDContractAddress, [
+        'function balanceOf(address account) view returns (uint256)',
+    ], provider);
+
+    const balancePromises = accounts.map(async (account) => {
+        const balance = await contract.balanceOf(account);
+        return { account, balance };
+    });
+
+    const balances = await Promise.all(balancePromises);
+
+    balances.forEach(({ account, balance }) => {
+        // send email if balance is low
+        if (balance.lt(parseEther('0.05'))) {
+            sendEmail({
+                to: 'developers@impactmarket.com',
+                from: 'hello@impactmarket.com',
+                subject: 'Low cUSD balance',
+                text: `cUSD balance for ${account} is ${formatEther(balance)}`,
+            });
+        }
+    });
+
+}

--- a/packages/api/src/loaders/subscriber.ts
+++ b/packages/api/src/loaders/subscriber.ts
@@ -1,0 +1,72 @@
+import { utils, database, subscriber } from '@impactmarket/core';
+
+
+const subscriptionsChannel = 'subscriber-listener-status';
+const redisPIDCondigVariable = '@subscriber/processId';
+
+export function startSubscribers() {
+    if (process.env.NODE_ENV === 'development') {
+        return;
+    }
+
+    // this section considers two things. Many processes can run in parallel
+    // but only one should be allowed to run the subscriber. Besides that
+    // the api has a pre-start, which means, there can be two processes in parallel
+    // and so once again, we want to prevent that from happening
+
+    // if no process id is set, start the subscriber and set the process id
+    database.redisClient.get(redisPIDCondigVariable).then((processId) => {
+        if (processId === null) {
+            subscriber.start();
+            utils.Logger.info('⏱️ Chain Subscriber starting');
+            database.redisClient.set(redisPIDCondigVariable, process.pid);
+        }
+    });
+
+    // a single redis connection can't be used for everything
+    // it's necessary to have a read/write connection
+    // an event listener connection and an event publisher connection
+    const redisListener = database.redisClient.duplicate();
+    const redisPublisher = database.redisClient.duplicate();
+
+    // so the program will not close instantly
+    process.stdin.resume();
+
+    // create an handler to be called the the app exits
+    async function exitHandler(options: { exit?: boolean },) {
+        if (options.exit) {
+            database.redisClient.get(redisPIDCondigVariable).then((processId) => {
+                if (processId && parseInt(processId, 10) === process.pid) {
+                    utils.Logger.info('⏱️ Chain Subscriber stopping');
+                    database.redisClient.del(redisPIDCondigVariable);
+                    // emit the process being closed
+                    redisPublisher.publish('subscriber-listener-status', process.pid.toString()).then(() => {
+                        // eslint-disable-next-line no-process-exit
+                        process.exit();
+                    });
+                } else {
+                    // eslint-disable-next-line no-process-exit
+                    process.exit();
+                }
+            });
+        }
+    }
+
+    // catches ctrl+c event
+    process.on('SIGINT', exitHandler.bind(null, { exit: true }));
+    // catches "kill pid" (for example: nodemon restart)
+    process.on('SIGUSR1', exitHandler.bind(null, { exit: true }));
+    process.on('SIGUSR2', exitHandler.bind(null, { exit: true }));
+
+    redisListener.on('pmessage', (_, channel, msg) => {
+        if (channel === subscriptionsChannel) {
+            const processId = parseInt(msg, 10);
+            if (processId !== process.pid) {
+                subscriber.start();
+                utils.Logger.info('⏱️ Chain Subscriber starting');
+                database.redisClient.set(redisPIDCondigVariable, process.pid);
+            }
+        }
+
+    });
+}


### PR DESCRIPTION
This PR fixes #392

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR adds validation on a list of wallets separated by ";", verifying only their cUSD balance.
It also validates balances of LearnAndEarn levels. Currently, if it's not enough for another 100 users, it send an email with a warning.
And lastly, refactors the subscribers, to it avoid having two subscribers running at the same time.

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
no new tests