### PR TITLE
user repayment history

### DIFF
--- a/packages/api/src/controllers/v2/microcredit/list.ts
+++ b/packages/api/src/controllers/v2/microcredit/list.ts
@@ -2,7 +2,7 @@ import { services } from '@impactmarket/core';
 import { Response } from 'express';
 
 import { standardResponse } from '../../../utils/api';
-import { ListBorrowersRequestSchema } from '../../../validators/microcredit';
+import { ListBorrowersRequestSchema, RepaymentHistoryRequestSchema } from '../../../validators/microcredit';
 import { ValidatedRequest } from '../../../utils/queryValidator';
 import { RequestWithUser } from '../../../middlewares/core';
 
@@ -28,6 +28,26 @@ class MicroCreditController {
         }
         this.microCreditService
             .listBorrowers({ ...req.query, addedBy: req.user.address })
+            .then((r) => standardResponse(res, 200, true, r))
+            .catch((e) => standardResponse(res, 400, false, '', { error: e }));
+    };
+
+    // list borrowers using a loan manager account
+    getRepaymentsHistory = (
+        req: RequestWithUser & ValidatedRequest<RepaymentHistoryRequestSchema>,
+        res: Response
+    ) => {
+        if (req.user === undefined) {
+            standardResponse(res, 400, false, '', {
+                error: {
+                    name: 'USER_NOT_FOUND',
+                    message: 'User not identified!',
+                },
+            });
+            return;
+        }
+        this.microCreditService
+            .getRepaymentsHistory(req.query)
             .then((r) => standardResponse(res, 200, true, r))
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));
     };

--- a/packages/api/src/routes/v2/attestation/index.ts
+++ b/packages/api/src/routes/v2/attestation/index.ts
@@ -36,6 +36,9 @@ export default (app: Router): void => {
      *                type: string
      *                enum: [verify, send]
      *                required: true
+     *     responses:
+     *       "200":
+     *         description: OK
      *     security:
      *     - api_auth:
      *       - "write:modify":

--- a/packages/api/src/routes/v2/microcredit/list.ts
+++ b/packages/api/src/routes/v2/microcredit/list.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express';
 
 import { MicroCreditController } from '../../../controllers/v2/microcredit/list';
-import { listBorrowersValidator } from '../../../validators/microcredit';
+import { listBorrowersValidator, repaymentsHistoryValidator } from '../../../validators/microcredit';
 import { authenticateToken } from '../../../middlewares';
+import { cache } from '../../../middlewares/cache-redis';
+import { cacheIntervals } from '../../../utils/api';
 
 export default (route: Router): void => {
     const controller = new MicroCreditController();
@@ -15,6 +17,19 @@ export default (route: Router): void => {
      *     tags:
      *       - "microcredit"
      *     summary: "Get List of Borrowers by manager"
+     *     parameters:
+     *       - in: query
+     *         name: offset
+     *         schema:
+     *           type: integer
+     *         required: false
+     *         description: offset used for pagination
+     *       - in: query
+     *         name: limit
+     *         schema:
+     *           type: integer
+     *         required: false
+     *         description: limit used for pagination
      *     responses:
      *       "200":
      *         description: OK
@@ -26,6 +41,59 @@ export default (route: Router): void => {
         '/borrowers/:query?',
         authenticateToken,
         listBorrowersValidator,
+        cache(cacheIntervals.fiveMinutes),
         controller.listBorrowers
+    );
+
+    /**
+     * @swagger
+     *
+     * /microcredit/repayment-history:
+     *   get:
+     *     tags:
+     *       - "microcredit"
+     *     summary: "Get repayments history of a user"
+     *     parameters:
+     *       - in: query
+     *         name: offset
+     *         schema:
+     *           type: integer
+     *         required: false
+     *         description: offset used for pagination
+     *       - in: query
+     *         name: limit
+     *         schema:
+     *           type: integer
+     *         required: false
+     *         description: limit used for pagination
+     *       - in: query
+     *         name: loanId
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: loan id of the user
+     *       - in: query
+     *         name: borrower
+     *         schema:
+     *           type: string
+     *         required: true
+     *         description: borrower address
+     *     responses:
+     *       "200":
+     *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/getRepaymentsHistory'
+     *     security:
+     *     - api_auth:
+     *       - "write:modify":
+     */
+    route.get(
+        '/repayment-history/:query?',
+        authenticateToken,
+        repaymentsHistoryValidator,
+        cache(cacheIntervals.fiveMinutes),
+        controller.getRepaymentsHistory
     );
 };

--- a/packages/api/src/validators/microcredit.ts
+++ b/packages/api/src/validators/microcredit.ts
@@ -10,8 +10,15 @@ import {
 const validator = createValidator();
 
 const queryListBorrowersSchema = defaultSchema.object({
-    offset: Joi.number().optional(),
-    limit: Joi.number().optional(),
+    offset: Joi.number().optional().default(0),
+    limit: Joi.number().optional().max(20).default(10),
+});
+
+const queryRepaymentsHistorySchema = defaultSchema.object({
+    offset: Joi.number().optional().default(0),
+    limit: Joi.number().optional().max(20).default(5),
+    loanId: Joi.number().required(),
+    borrower: Joi.string().required(),
 });
 
 interface ListBorrowersRequestSchema extends ValidatedRequestSchema {
@@ -21,6 +28,16 @@ interface ListBorrowersRequestSchema extends ValidatedRequestSchema {
     };
 }
 
-const listBorrowersValidator = validator.query(queryListBorrowersSchema);
+interface RepaymentHistoryRequestSchema extends ValidatedRequestSchema {
+    [ContainerTypes.Query]: {
+        offset?: number;
+        limit?: number;
+        loanId: number;
+        borrower: string;
+    };
+}
 
-export { listBorrowersValidator, ListBorrowersRequestSchema };
+const listBorrowersValidator = validator.query(queryListBorrowersSchema);
+const repaymentsHistoryValidator = validator.query(queryRepaymentsHistorySchema);
+
+export { listBorrowersValidator, repaymentsHistoryValidator, ListBorrowersRequestSchema, RepaymentHistoryRequestSchema };

--- a/packages/core/src/contracts/MicrocreditABI.json
+++ b/packages/core/src/contracts/MicrocreditABI.json
@@ -41,5 +41,39 @@
     ],
     "name": "LoanAdded",
     "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_userAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_loanId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_repaymentId",
+        "type": "uint256"
+      }
+    ],
+    "name": "userLoanRepayments",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "date",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]


### PR DESCRIPTION
This PR fixes #587

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR gets and cache repayments for a given user.
It also forces some validation on the query. Does not allow large queries (like, limit=999) and adds a default value to limit and offset.

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->

no new tests