### PR TITLE
change webSocketProvider to jsonRpcProvider to getLogs()

### DIFF
--- a/packages/core/src/subscriber/index.ts
+++ b/packages/core/src/subscriber/index.ts
@@ -22,7 +22,7 @@ let availableCommunities: Community[];
 
 export const start = async (): Promise<void> => {
     provider = new ethers.providers.WebSocketProvider(config.webSocketUrl);
-    jsonRpcProvider = new ethers.providers.WebSocketProvider(config.jsonRpcUrl);
+    jsonRpcProvider = new ethers.providers.JsonRpcProvider(config.jsonRpcUrl);
     providerFallback = new ethers.providers.WebSocketProvider(
         config.webSocketUrlFallback
     );


### PR DESCRIPTION
This PR fixes #594 

## Changes
changed the provider type from `webSocketProvider` to `jsonRpcProvider` to be used to recover previous events (getLogs()).

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->