### PR TITLE
Fix provider fallback

### DIFF
--- a/packages/core/src/subscriber/chainSubscribers.ts
+++ b/packages/core/src/subscriber/chainSubscribers.ts
@@ -78,22 +78,11 @@ class ChainSubscribers {
         let rawLogs: ethers.providers.Log[] = [];
 
         try {
-            rawLogs = await provider.getLogs({
-                fromBlock: startFromBlock,
-                toBlock: 'latest',
-                topics: this.filterTopics,
-            });
-
+            rawLogs = await this._getLogs(startFromBlock, provider);
             utils.Logger.info('Got logs from main provider!');
         } catch (error) {
             utils.Logger.error('Failed to get logs from main provider!', error);
-            
-            rawLogs = await fallbackProvider.getLogs({
-                fromBlock: startFromBlock,
-                toBlock: 'latest',
-                topics: this.filterTopics,
-            });
-
+            rawLogs = await this._getLogs(startFromBlock, fallbackProvider);
             utils.Logger.info('Got logs from fallback provider!');
         }
 
@@ -114,6 +103,14 @@ class ChainSubscribers {
             await this._filterAndProcessEvent(logs[x]);
         }
         utils.Logger.info('Past events recovered successfully!');
+    }
+
+    async _getLogs(startFromBlock: number, provider: ethers.providers.JsonRpcProvider) {
+        return provider.getLogs({
+            fromBlock: startFromBlock,
+            toBlock: 'latest',
+            topics: this.filterTopics,
+        });
     }
 
     _setupListener(provider: ethers.providers.WebSocketProvider) {

--- a/packages/core/src/subscriber/chainSubscribers.ts
+++ b/packages/core/src/subscriber/chainSubscribers.ts
@@ -8,6 +8,7 @@ import { sendNotification } from '../utils/pushNotification';
 class ChainSubscribers {
     provider: ethers.providers.WebSocketProvider;
     jsonRpcProvider: ethers.providers.JsonRpcProvider;
+    jsonRpcProviderFallback: ethers.providers.JsonRpcProvider;
     ifaceCommunityAdmin: ethers.utils.Interface;
     ifaceCommunity: ethers.utils.Interface;
     ifaceMicrocredit: ethers.utils.Interface;
@@ -17,10 +18,12 @@ class ChainSubscribers {
     constructor(
         webSocketProvider: ethers.providers.WebSocketProvider,
         jsonRpcProvider: ethers.providers.JsonRpcProvider,
+        jsonRpcProviderFallback: ethers.providers.JsonRpcProvider,
         communities: Map<string, number>
     ) {
         this.provider = webSocketProvider;
         this.jsonRpcProvider = jsonRpcProvider;
+        this.jsonRpcProviderFallback = jsonRpcProviderFallback;
         this.ifaceCommunityAdmin = new ethers.utils.Interface(
             contracts.CommunityAdminABI
         );
@@ -56,12 +59,12 @@ class ChainSubscribers {
         this._setupListener(this.provider);
         // we start the listener alongside with the recover system
         // so we know we don't lose events.
-        this._runRecoveryTxs(this.jsonRpcProvider).then(() =>
+        this._runRecoveryTxs(this.jsonRpcProvider, this.jsonRpcProviderFallback).then(() =>
             services.app.ImMetadataService.removeRecoverBlock()
         );
     }
 
-    async _runRecoveryTxs(provider: ethers.providers.JsonRpcProvider) {
+    async _runRecoveryTxs(provider: ethers.providers.JsonRpcProvider, fallbackProvider: ethers.providers.JsonRpcProvider) {
         utils.Logger.info('Recovering past events...');
         let startFromBlock: number;
         let lastBlockCached = await database.redisClient.get('lastBlock');
@@ -72,11 +75,27 @@ class ChainSubscribers {
             startFromBlock = parseInt(lastBlockCached, 10);
         }
 
-        const rawLogs = await provider.getLogs({
-            fromBlock: startFromBlock,
-            toBlock: 'latest',
-            topics: this.filterTopics,
-        });
+        let rawLogs: ethers.providers.Log[] = [];
+
+        try {
+            rawLogs = await provider.getLogs({
+                fromBlock: startFromBlock,
+                toBlock: 'latest',
+                topics: this.filterTopics,
+            });
+
+            utils.Logger.info('Got logs from main provider!');
+        } catch (error) {
+            utils.Logger.error('Failed to get logs from main provider!', error);
+            
+            rawLogs = await fallbackProvider.getLogs({
+                fromBlock: startFromBlock,
+                toBlock: 'latest',
+                topics: this.filterTopics,
+            });
+
+            utils.Logger.info('Got logs from fallback provider!');
+        }
 
         const logs = rawLogs.sort((a, b) => {
             if (a.blockNumber > b.blockNumber) {

--- a/packages/core/src/subscriber/chainSubscribers.ts
+++ b/packages/core/src/subscriber/chainSubscribers.ts
@@ -59,9 +59,13 @@ class ChainSubscribers {
         this._setupListener(this.provider);
         // we start the listener alongside with the recover system
         // so we know we don't lose events.
-        this._runRecoveryTxs(this.jsonRpcProvider, this.jsonRpcProviderFallback).then(() =>
-            services.app.ImMetadataService.removeRecoverBlock()
-        );
+        this._runRecoveryTxs(this.jsonRpcProvider, this.jsonRpcProviderFallback)
+            .then(() =>
+                services.app.ImMetadataService.removeRecoverBlock()
+            )
+            .catch((error) =>
+                utils.Logger.error('Failed to recover past events!', error)
+            );
     }
 
     async _runRecoveryTxs(provider: ethers.providers.JsonRpcProvider, fallbackProvider: ethers.providers.JsonRpcProvider) {

--- a/packages/core/src/subscriber/index.ts
+++ b/packages/core/src/subscriber/index.ts
@@ -162,7 +162,8 @@ function reconnectChainSubscriber() {
 function startChainSubscriber(fallback?: boolean): ChainSubscribers {
     return new ChainSubscribers(
         fallback ? providerFallback : provider,
-        fallback ? jsonRpcProviderFallback : jsonRpcProvider,
+        jsonRpcProvider,
+        jsonRpcProviderFallback,
         new Map(availableCommunities.map((c) => [c.contractAddress!, c.id]))
     );
 }

--- a/packages/core/tests/integration/subscriber/communityAdmin.test.ts
+++ b/packages/core/tests/integration/subscriber/communityAdmin.test.ts
@@ -88,6 +88,7 @@ describe('communityAdmin', () => {
         subscribers = new ChainSubscribers(
             provider as any,
             provider,
+            provider, // fallback
             new Map([]),
         );
     });

--- a/packages/core/tests/integration/subscriber/microcredit.test.ts
+++ b/packages/core/tests/integration/subscriber/microcredit.test.ts
@@ -84,6 +84,7 @@ describe('Microcredit', () => {
         subscribers = new ChainSubscribers(
             provider as any,
             provider,
+            provider, // fallback
             new Map([]),
         );
     });


### PR DESCRIPTION
no task.

## Changes
Add a `jsonRpcProviderFallback` to be used on `provider.getLogs()`

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->