### PR TITLE
add support for translated validation messages

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -6,6 +6,8 @@ import * as jwt from './jwt';
 import { Logger } from './logger';
 import * as util from './util';
 import * as pushNotification from './pushNotification';
+import * as prismic from './prismic';
+import locales from './locale.json';
 
 /**
  * format object's values to number if they are numbers in string format
@@ -32,5 +34,7 @@ export {
     util,
     jwt,
     cache,
-    pushNotification
+    pushNotification,
+    prismic,
+    locales
 };

--- a/packages/core/src/utils/prismic.ts
+++ b/packages/core/src/utils/prismic.ts
@@ -1,6 +1,6 @@
 import * as prismic from '@prismicio/client';
 
-const endpoint = prismic.getEndpoint(process.env.PRISMIC_REPO!);
+const endpoint = prismic.getRepositoryEndpoint(process.env.PRISMIC_REPO!);
 const accessToken = process.env.PRISMIC_ACCESS_TOKEN;
 
 export const client = prismic.createClient(endpoint, { accessToken });


### PR DESCRIPTION
This PR adds support for translations on messages sent for phone number/email validation

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

## Tests

<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
Manually tested