### PR TITLE
lambda authorizer

### DIFF
--- a/services/authorizer/.gitignore
+++ b/services/authorizer/.gitignore
@@ -1,0 +1,5 @@
+# package directories
+node_modules
+
+# Serverless directories
+.serverless

--- a/services/authorizer/.mocharc.json
+++ b/services/authorizer/.mocharc.json
@@ -1,0 +1,9 @@
+{
+    "extension": ["ts"],
+    "spec": "tests/**/*.test.ts",
+    "require": ["ts-node/register", "tsconfig-paths/register"],
+    "delay": false,
+    "bail": false,
+    "watch": false,
+    "timeout": 30000
+}

--- a/services/authorizer/README.md
+++ b/services/authorizer/README.md
@@ -1,0 +1,20 @@
+Configure Serverless Framework
+```
+npm install -g serverless
+
+serverless config credentials \
+    --provider aws \
+    --key AWS_ACCESS_KEY_ID \
+    --secret AWS_SECRET_ACCESS_KEY
+```
+
+Invoke Local
+```
+sls invoke local -f function-name
+```
+
+Deploy lambda
+```
+cd services/authorizer
+sls deploy --stage STAGE --aws-profile PROFILE
+```

--- a/services/authorizer/README.md
+++ b/services/authorizer/README.md
@@ -1,4 +1,9 @@
-Configure Serverless Framework
+## Lambda Authorizer
+
+> The purpose of the lambda "authorizer" is to validate a JSON Web Token (JWT) and ensure the authenticity and authorization of requests received at our API Gateway. The requested JWT is not the same as the one used by the general API users and must be created using a specific "secret key".
+This lambda will be triggered for each request made to our API Gateway ( eg. to get images) and to be successful you just need to send the JWT token in the "Authorization" header of the request.
+
+### Configure Serverless Framework
 ```
 npm install -g serverless
 
@@ -8,12 +13,12 @@ serverless config credentials \
     --secret AWS_SECRET_ACCESS_KEY
 ```
 
-Invoke Local
+### Invoke Local
 ```
 sls invoke local -f function-name
 ```
 
-Deploy lambda
+### Deploy lambda
 ```
 cd services/authorizer
 sls deploy --stage STAGE --aws-profile PROFILE

--- a/services/authorizer/handler.ts
+++ b/services/authorizer/handler.ts
@@ -1,0 +1,41 @@
+import jwt from 'jsonwebtoken';
+
+const SECRET = process.env.SECRET;
+
+export const authorizer = async (event: any, _context: any) => {
+  if (!SECRET) {
+    throw new Error('Invalid JWT Secret');
+  }
+
+  const token = event.authorizationToken;
+
+  if (!token) {
+    throw new Error('JWT Token required');
+  }
+
+  try {
+    const decodedToken = jwt.verify(token, SECRET);
+    return generatePolicy(decodedToken.sub, 'Allow', event.methodArn);
+  } catch (error) {
+    console.error('Failed to validate JWT Token:', error);
+    throw new Error('Invalid Token');
+  }
+};
+
+const generatePolicy = (principalId, effect, resource) => {
+  const authResponse = {
+    principalId,
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: effect,
+          Resource: resource,
+        },
+      ],
+    },
+  };
+
+  return authResponse;
+}

--- a/services/authorizer/package.json
+++ b/services/authorizer/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "@impactmarket/authorizer",
+    "version": "1.0.0",
+    "scripts": {
+        "build": "tsc",
+        "test": "NODE_ENV=test mocha"
+    },
+    "author": "impact-market",
+    "license": "Apache-2.0",
+    "engines": {
+        "node": "18.x"
+    },
+    "devDependencies": {
+        "@types/aws-lambda": "8.10.102",
+        "@types/node": "18.16.4",
+        "serverless-bundle": "fancywriter/serverless-bundle#c53aa061ed83f683dbb665f9734fc1dca624788a"
+    },
+    "dependencies": {
+        "jsonwebtoken": "9.0.0"
+    }
+}

--- a/services/authorizer/serverless.yml
+++ b/services/authorizer/serverless.yml
@@ -1,0 +1,21 @@
+service: authorizer
+
+frameworkVersion: '3'
+useDotenv: true
+
+provider:
+  name: aws
+  runtime: nodejs18.x
+  region: ${env:AWS_REGION}
+
+functions:
+  authorizer:
+    handler: handler.authorizer
+    events:
+      - http:
+          path: authorizer
+          method: post
+          private: true
+
+plugins:
+  - serverless-bundle


### PR DESCRIPTION
This PR fixes #564
## Changes
Create a lambda to be used as an authorizer on API Gateway.
This authorizer will validate a JWT Token before triggering another lambda.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
