### PR TITLE
microcredit demographics route

### DIFF
--- a/packages/api/src/controllers/v2/microcredit/list.ts
+++ b/packages/api/src/controllers/v2/microcredit/list.ts
@@ -83,6 +83,13 @@ class MicroCreditController {
             .then(r => standardResponse(res, 200, true, r))
             .catch(e => standardResponse(res, 400, false, '', { error: e }));
     };
+
+    demographics = (req: RequestWithUser, res: Response) => {
+        this.microCreditService
+            .demographics()
+            .then(r => standardResponse(res, 200, true, r))
+            .catch(e => standardResponse(res, 400, false, '', { error: e }));
+    };
 }
 
 export { MicroCreditController };

--- a/packages/api/src/routes/v2/microcredit/list.ts
+++ b/packages/api/src/routes/v2/microcredit/list.ts
@@ -227,4 +227,27 @@ export default (route: Router): void => {
         cache(cacheIntervals.fiveMinutes),
         controller.getRepaymentsHistory
     );
+
+    /**
+     * @swagger
+     *
+     * /microcredit/demographics:
+     *   get:
+     *     tags:
+     *       - "microcredit"
+     *     summary: "Get Microcredit demographics"
+     *     description: "Get Microcredit demographics"
+     *     responses:
+     *       "200":
+     *         description: OK
+     *         content:
+     *           application/json:
+     *             schema:
+     *               $ref: '#/components/schemas/demographics'
+     */
+    route.get(
+        '/demographics',
+        cache(cacheIntervals.oneHour),
+        controller.demographics
+    )
 };

--- a/packages/core/src/subgraph/queries/microcredit.ts
+++ b/packages/core/src/subgraph/queries/microcredit.ts
@@ -222,14 +222,14 @@ export const getMicroCreditStatsLastDays = async (
 export type SubgraphGetBorrowersQuery = {
     offset?: number;
     limit?: number;
-    addedBy: string;
+    addedBy?: string;
     claimed?: boolean;
-    filter?: 'repaid' | 'needHelp';
+    filter?: 'repaid' | 'needHelp' | 'all';
     orderBy?: 'amount' | 'period' | 'lastRepayment' | 'lastDebt';
     orderDirection?: 'desc' | 'asc';
 };
 
-const filtersToBorrowersQuery = (filter: 'repaid' | 'needHelp' | undefined): string => {
+const filtersToBorrowersQuery = (filter: 'repaid' | 'needHelp' | 'all' | undefined): string => {
     switch (filter) {
         case 'repaid':
             return 'lastDebt: 0';
@@ -238,6 +238,8 @@ const filtersToBorrowersQuery = (filter: 'repaid' | 'needHelp' | undefined): str
             const date = new Date();
             date.setMonth(date.getMonth() - 3);
             return `lastRepayment_lte: ${Math.floor(date.getTime() / 1000)}`;
+        case 'all':
+            return '';
         default:
             return 'lastDebt_not: 0';
     }
@@ -253,7 +255,7 @@ const countGetBorrowers = async (query: SubgraphGetBorrowersQuery): Promise<numb
                 first: 1000
                 skip: 0
                 where: {
-                    addedBy: "${addedBy.toLowerCase()}"
+                    ${addedBy ? `addedBy: "${addedBy.toLowerCase()}"` : ''}
                     ${claimed ? 'claimed_not: null' : ''}
                     ${filtersToBorrowersQuery(filter)}
                 }
@@ -333,7 +335,7 @@ export const getBorrowers = async (
                 first: ${limit ? limit : 10}
                 skip: ${offset ? offset : 0}
                 where: {
-                    addedBy: "${addedBy.toLowerCase()}"
+                    ${addedBy ? `addedBy: "${addedBy.toLowerCase()}"` : ''}
                     ${claimed ? 'claimed_not: null' : ''}
                     ${filtersToBorrowersQuery(filter)}
                     ${filter === 'repaid' ? `borrower_in: ${JSON.stringify(countOrList)}` : ''}


### PR DESCRIPTION
This PR fixes #597 
## Changes
Add a route to return the Microcredit demographics containing:
- the number of users per gender for each country
- the age range of the users who borrowed, splited by:
  - ongoing payment
  - paid
  - overdue

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
