### PR TITLE
update borrowers query + borrower loans

### DIFF
--- a/packages/api/src/middlewares/index.ts
+++ b/packages/api/src/middlewares/index.ts
@@ -128,7 +128,7 @@ export function verifySignature(req: RequestWithUser, res: Response, next: NextF
             success: false,
             error: {
                 name: 'INVALID_SINATURE',
-                message: 'signature is invalid'
+                message: 'signature or message not provided'
             }
         });
         return;
@@ -144,14 +144,14 @@ export function verifySignature(req: RequestWithUser, res: Response, next: NextF
                 success: false,
                 error: {
                     name: 'EXPIRED_SIGNATURE',
-                    message: 'signature is expired'
+                    message: 'invalid timestamp'
                 }
             });
             return;
         }
         const expirationDate = new Date();
         expirationDate.setDate(expirationDate.getDate() - config.signatureExpiration);
-        if (parseInt(timestamp[0], 10) < expirationDate.getTime()) {
+        if (parseInt(timestamp[0], 10) < expirationDate.getTime() / 1000) {
             res.status(403).json({
                 success: false,
                 error: {
@@ -167,7 +167,7 @@ export function verifySignature(req: RequestWithUser, res: Response, next: NextF
             success: false,
             error: {
                 name: 'INVALID_SINATURE',
-                message: 'signature is invalid'
+                message: 'invalid signer'
             }
         });
     }

--- a/packages/api/src/routes/v2/microcredit/list.ts
+++ b/packages/api/src/routes/v2/microcredit/list.ts
@@ -52,16 +52,9 @@ export default (route: Router): void => {
      *         name: orderBy
      *         schema:
      *           type: string
-     *           enum: [amount, period, lastRepayment, lastDebt]
+     *           enum: [amount, amount:asc, amount:desc, period, period:asc, period:desc, lastRepayment, lastRepayment:asc, lastRepayment:desc, lastDebt, lastDebt:asc, lastDebt:desc]
      *         required: false
      *         description: order by
-     *       - in: query
-     *         name: orderDirection
-     *         schema:
-     *           type: string
-     *           enum: [desc, asc]
-     *         required: false
-     *         description: order direction
      *     responses:
      *       "200":
      *         description: OK
@@ -145,16 +138,9 @@ export default (route: Router): void => {
      *         name: orderBy
      *         schema:
      *           type: string
-     *           enum: [appliedOn]
+     *           enum: [appliedOn, appliedOn:asc, appliedOn:desc]
      *         required: false
      *         description: order by
-     *       - in: query
-     *         name: orderDirection
-     *         schema:
-     *           type: string
-     *           enum: [desc, asc]
-     *         required: false
-     *         description: order direction
      *     responses:
      *       "200":
      *         description: OK

--- a/packages/api/src/validators/microcredit.ts
+++ b/packages/api/src/validators/microcredit.ts
@@ -10,16 +10,26 @@ type ListBorrowersType = {
     limit?: number;
     claimed?: boolean;
     filter?: 'repaid' | 'needHelp';
-    orderBy?: 'amount' | 'period' | 'lastRepayment' | 'lastDebt';
-    orderDirection?: 'desc' | 'asc';
+    orderBy?:
+        | 'amount'
+        | 'amount:asc'
+        | 'amount:desc'
+        | 'period'
+        | 'period:asc'
+        | 'period:desc'
+        | 'lastRepayment'
+        | 'lastRepayment:asc'
+        | 'lastRepayment:desc'
+        | 'lastDebt'
+        | 'lastDebt:asc'
+        | 'lastDebt:desc';
 };
 
 type ListApplicationsType = {
     offset?: number;
     limit?: number;
     filter?: 'pending' | 'approved' | 'rejected';
-    orderBy?: 'appliedOn';
-    orderDirection?: 'desc' | 'asc';
+    orderBy?: 'appliedOn' | 'appliedOn:asc' | 'appliedOn:desc';
 };
 
 const queryListBorrowersSchema = defaultSchema.object<ListBorrowersType>({
@@ -27,16 +37,29 @@ const queryListBorrowersSchema = defaultSchema.object<ListBorrowersType>({
     limit: Joi.number().optional().max(20).default(10),
     claimed: Joi.boolean().optional(),
     filter: Joi.string().optional().valid('repaid', 'needHelp'),
-    orderBy: Joi.string().optional().valid('amount', 'period', 'lastRepayment', 'lastDebt'),
-    orderDirection: Joi.string().optional().valid('desc', 'asc')
+    orderBy: Joi.string()
+        .optional()
+        .valid(
+            'amount',
+            'amount:asc',
+            'amount:desc',
+            'period',
+            'period:asc',
+            'period:desc',
+            'lastRepayment',
+            'lastRepayment:asc',
+            'lastRepayment:desc',
+            'lastDebt',
+            'lastDebt:asc',
+            'lastDebt:desc'
+        )
 });
 
 const queryListApplicationsSchema = defaultSchema.object<ListApplicationsType>({
     offset: Joi.number().optional().default(0),
     limit: Joi.number().optional().max(20).default(10),
     filter: Joi.string().optional().valid('pending', 'approved', 'rejected'),
-    orderBy: Joi.string().optional().valid('appliedOn'),
-    orderDirection: Joi.string().optional().valid('desc', 'asc')
+    orderBy: Joi.string().optional().valid('appliedOn', 'appliedOn:asc', 'appliedOn:desc')
 });
 
 const queryRepaymentsHistorySchema = defaultSchema.object({

--- a/packages/core/tests/integration/v2/microcredit.test.ts
+++ b/packages/core/tests/integration/v2/microcredit.test.ts
@@ -6,10 +6,13 @@ import { sequelizeSetup, truncate } from '../../config/sequelizeSetup';
 import UserFactory from '../../factories/user';
 import MicroCreditCreate from '../../../src/services/microcredit/create';
 import MicroCreditList from '../../../src/services/microcredit/list';
+import { SinonStub, stub } from 'sinon';
+import * as microCreditQueries from '../../../src/subgraph/queries/microcredit';
 
 describe('microCredit', () => {
     let sequelize: Sequelize;
     let users: AppUser[];
+    let stubMicroCreditQueries: SinonStub<[borrower: string], Promise<number>>;
     const microCreditCreate = new MicroCreditCreate();
     const microCreditList = new MicroCreditList();
 
@@ -17,12 +20,14 @@ describe('microCredit', () => {
         sequelize = sequelizeSetup();
         await sequelize.sync();
         users = await UserFactory({ n: 5 });
+        stubMicroCreditQueries = stub(microCreditQueries, 'getBorrowerLoansCount').resolves(2);
     });
 
     after(async () => {
         await truncate(sequelize, 'appUser');
         await truncate(sequelize, 'microCreditDocs');
         await truncate(sequelize);
+        stubMicroCreditQueries.reset();
     });
 
     describe('docs', () => {


### PR DESCRIPTION
no task linked

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR changes the borrowers list to allow writting queries like on the other list, such as `orderBy=whatever:asc` instead of having the orderDirection separated. It also includes the number of loans on the borrower endpoint and fixes the signatures expiration.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
no new tests