### PR TITLE
fix community ubi demographics

### DIFF
--- a/services/community-metrics/handler.ts
+++ b/services/community-metrics/handler.ts
@@ -1,5 +1,5 @@
 import { verifyDeletedAccounts } from './src/user';
-import { calcuateCommunitiesMetrics } from './src/calcuateCommunitiesMetrics';
+import { calcuateCommunitiesMetrics, calcuateCommunitiesDemographics } from './src/calcuateCommunitiesMetrics';
 import { calcuateGlobalMetrics } from './src/calcuateGlobalMetrics';
 import { services } from '@impactmarket/core';
 import { updateExchangeRates } from './src/updateExchangeRates';
@@ -29,10 +29,8 @@ export const calculate = async (event, context) => {
     try {
         const globalDemographicsService =
             new services.global.GlobalDemographicsService();
-        const communityDemographicsService =
-            new services.ubi.CommunityDemographicsService();
 
-        await communityDemographicsService.calculate();
+        await calcuateCommunitiesDemographics();
         await globalDemographicsService.calculate();
     } catch (error) {
         console.error('Error communityDemographicsService/globalDemographicsService: ', error);


### PR DESCRIPTION
This PR fixes #605 

## Changes
changed the `community-metrics` lambda to calculate the community ubi demographics getting the beneficiaries from TheGraph.
function added on the `calcuateCommunitiesMetrics` file to reuse the beneficiary's addresses already obtained to calculate the metrics for each community. 

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
