### PR TITLE
filter beneficiaries by inactivity

### DIFF
--- a/packages/api/src/controllers/v2/community/details.ts
+++ b/packages/api/src/controllers/v2/community/details.ts
@@ -103,7 +103,7 @@ class CommunityController {
                     : undefined,
                 orderBy,
                 lastActivity_lt && typeof lastActivity_lt === 'string'
-                    ? parseInt(lastActivity_lt)
+                    ? parseInt(lastActivity_lt, 10)
                     : undefined,
             )
             .then((r) => standardResponse(res, 200, true, r))

--- a/packages/api/src/controllers/v2/community/details.ts
+++ b/packages/api/src/controllers/v2/community/details.ts
@@ -67,6 +67,7 @@ class CommunityController {
             loginInactivity,
             search,
             orderBy,
+            lastActivity_lt,
         } = req.query;
         if (state === undefined || typeof state !== 'string') {
             state = undefined;
@@ -100,7 +101,10 @@ class CommunityController {
                 search !== undefined && typeof search === 'string'
                     ? search
                     : undefined,
-                orderBy
+                orderBy,
+                lastActivity_lt && typeof lastActivity_lt === 'string'
+                    ? parseInt(lastActivity_lt)
+                    : undefined,
             )
             .then((r) => standardResponse(res, 200, true, r))
             .catch((e) => standardResponse(res, 400, false, '', { error: e }));

--- a/packages/api/src/routes/v2/community/details.ts
+++ b/packages/api/src/routes/v2/community/details.ts
@@ -248,6 +248,10 @@ export default (route: Router): void => {
      *           type: string
      *         required: false
      *         description: order key and order direction separated by colon (claimed:desc)
+     *       - in: query
+     *         name: lastActivity_lt
+     *         required: false
+     *         descripition: timestamp to filter the inactive beneficiaries
      *     security:
      *     - BearerToken: []
      *     responses:

--- a/packages/api/src/services/referral/index.ts
+++ b/packages/api/src/services/referral/index.ts
@@ -110,10 +110,10 @@ export const getReferralCode = async (userId: number, campaignId: number) => {
     });
 
     if (!user) {
-        throw new BaseError('USER_NOT_FOUND', 'User not found');
+        throw new utils.BaseError('USER_NOT_FOUND', 'User not found');
     }
     if (!user.phoneValidated || !user.emailValidated) {
-        throw new BaseError('NOT_ILLEGIBLE', 'User has not verified account');
+        throw new utils.BaseError('NOT_ILLEGIBLE', 'User has not verified account');
     }
 
     const referralCodeExists = await appReferralCode.findOne({
@@ -202,7 +202,7 @@ export const useReferralCode = async (userId: number, referralCode: string) => {
         );
     } catch (error) {
         if (error.error?.message?.indexOf('ReferralLink') !== -1) {
-            throw new BaseError(
+            throw new utils.BaseError(
                 'REFERRAL_LINK_ERROR',
                 error.error?.message?.match(/\"execution reverted: ([\w\s\d:]*)\",/)[1]
             );


### PR DESCRIPTION
This PR fixes #673 

## Changes
add the `lastActivity_lt` query field (the same used on TheGraph) to specify a timestamp to filter "inactive" beneficiaries.
Inactive beneficiaries are beneficiaries with the state "active" that didn't have any activity in the last X days (X is defined by the `lastActivity_lt`).

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
