### PR TITLE
update reward on triggering

### DIFF
--- a/packages/core/src/services/learnAndEarn/syncRemote.ts
+++ b/packages/core/src/services/learnAndEarn/syncRemote.ts
@@ -51,6 +51,16 @@ async function getPrismicLearnAndEarn() {
                     continue;
                 }
 
+                // update reward
+                await models.learnAndEarnLevel.update({
+                    totalReward: prismicLevel.data.reward
+                }, {
+                    where: {
+                        id: prismicLevel.data.id,
+                    },
+                    transaction: t,
+                });
+
                 const lang = prismicLevel.lang ? prismicLevel.lang.split('-')[0] : 'en';
                 await models.learnAndEarnPrismicLevel.create({
                     prismicId: prismicLevel.id,


### PR DESCRIPTION
no task.

## Changes
the `reward` was not being updated when the webhook is triggered

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
