### PR TITLE
borrower last loan status + "inlcude" on query

### DIFF
--- a/packages/api/src/controllers/v2/microcredit/list.ts
+++ b/packages/api/src/controllers/v2/microcredit/list.ts
@@ -79,7 +79,10 @@ class MicroCreditController {
             return;
         }
         this.microCreditService
-            .getBorrower(req.query)
+            .getBorrower({
+                ...req.query,
+                include: req.query.include instanceof Array ? req.query.include : [req.query.include]
+            })
             .then(r => standardResponse(res, 200, true, r))
             .catch(e => standardResponse(res, 400, false, '', { error: e }));
     };

--- a/packages/api/src/routes/v2/microcredit/list.ts
+++ b/packages/api/src/routes/v2/microcredit/list.ts
@@ -82,6 +82,16 @@ export default (route: Router): void => {
      *           type: string
      *         required: true
      *         description: borrower address
+     *       - in: query
+     *         name: include
+     *         schema:
+     *           type: array
+     *           items:
+     *             type: string
+     *         required: false
+     *         enum: [docs, forms]
+     *         example: [docs, forms]
+     *         description: what to include in the response
      *     responses:
      *       "200":
      *         description: OK

--- a/packages/api/src/validators/microcredit.ts
+++ b/packages/api/src/validators/microcredit.ts
@@ -77,8 +77,9 @@ const queryPreSignerUrlFromAWSSchema = defaultSchema.object({
     mime: Joi.string().required()
 });
 
-const queryGetBorrowerSchema = defaultSchema.object<{ address: string }>({
-    address: Joi.string().required()
+const queryGetBorrowerSchema = defaultSchema.object<{ address: string; include: string | string[] }>({
+    address: Joi.string().required(),
+    include: Joi.alternatives(Joi.string(), Joi.array<string[]>()).optional().default([])
 });
 
 interface ListBorrowersRequestSchema extends ValidatedRequestSchema {
@@ -107,6 +108,7 @@ interface PreSignerUrlFromAWSRequestSchema extends ValidatedRequestSchema {
 interface GetBorrowerRequestSchema extends ValidatedRequestSchema {
     [ContainerTypes.Query]: {
         address: string;
+        include: string | string[];
     };
 }
 

--- a/packages/core/src/subgraph/queries/microcredit.ts
+++ b/packages/core/src/subgraph/queries/microcredit.ts
@@ -296,6 +296,32 @@ const countGetBorrowers = async (query: SubgraphGetBorrowersQuery): Promise<numb
     return borrowers;
 };
 
+export const getUserLastLoanStatusFromSubgraph = async (userAddress: string): Promise<LoanStatus> => {
+    const graphqlQuery = {
+        operationName: 'borrowers',
+        query: `query borrowers {
+                borrower(id: "${userAddress.toLowerCase()}") {
+                    lastLoanStatus
+                }
+            }`
+    };
+
+    const response = await axiosMicrocreditSubgraph.post<
+        any,
+        {
+            data: {
+                data: {
+                    borrower: {
+                        lastLoanStatus: LoanStatus;
+                    };
+                };
+            };
+        }
+    >('', graphqlQuery);
+
+    return response.data?.data.borrower.lastLoanStatus;
+};
+
 export const getBorrowers = async (
     query: SubgraphGetBorrowersQuery
 ): Promise<{

--- a/packages/core/tests/integration/v2/microcredit.test.ts
+++ b/packages/core/tests/integration/v2/microcredit.test.ts
@@ -39,7 +39,7 @@ describe('microCredit', () => {
                 }
             ]);
 
-            const res = await microCreditList.getBorrower({ address: users[0].address });
+            const res = await microCreditList.getBorrower({ address: users[0].address, include: ['docs'] });
 
             expect(res.docs.length).to.be.equals(1);
             expect(res.docs[0]).to.include({


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR adds functionality to return a borrowers last loan status on the `/borrower` endpoint. Also changes the endpoint to require what to include on the query.

The status are
```javascript
export enum LoanStatus {
    NO_LOAN = 0,
    FORM_DRAFT = 1,
    PENDING_REVIEW = 2,
    REQUEST_CHANGES = 3,
    APPROVED = 4,
    REJECTED = 5,
    PENDING_CLAIM = 6,
    CLAIMED = 7,
    FULL_REPAID = 8,
    CANCELED = 9
}
```

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
