### PR TITLE
[feature] group txs by block

### DIFF
--- a/packages/core/src/services/microcredit/create.ts
+++ b/packages/core/src/services/microcredit/create.ts
@@ -3,7 +3,7 @@ import { BaseError } from '../../utils';
 import { MicroCreditApplication, MicroCreditApplicationStatus } from '../../interfaces/microCredit/applications';
 import { MicroCreditContentStorage } from '../../services/storage';
 import { NotificationType } from '../../interfaces/app/appNotification';
-import { Op } from 'sequelize';
+import { Op, Transaction } from 'sequelize';
 import { config } from '../../..';
 import { models } from '../../database';
 import { sendEmail } from '../../services/email';
@@ -66,9 +66,9 @@ export default class MicroCreditCreate {
         return microCreditDocs;
     }
 
-    public async updateApplication(applicationId: number[], status: number[]): Promise<void>;
-    public async updateApplication(walletAddress: string[], status: number[]): Promise<void>;
-    public async updateApplication(arg: (number | string)[], status: number[]) {
+    public async updateApplication(applicationId: number[], status: number[], transaction?: Transaction): Promise<void>;
+    public async updateApplication(walletAddress: string[], status: number[], transaction?: Transaction): Promise<void>;
+    public async updateApplication(arg: (number | string)[], status: number[], transaction?: Transaction) {
         const updateApplicationStatus = async (applicationId: number, status: number) => {
             await models.microCreditApplications.update(
                 {
@@ -78,7 +78,8 @@ export default class MicroCreditCreate {
                 {
                     where: {
                         id: applicationId
-                    }
+                    },
+                    transaction
                 }
             );
         };
@@ -139,7 +140,7 @@ export default class MicroCreditCreate {
             .map(application => application.user)
             .filter(user => user !== undefined) as AppUserModel[];
 
-        await sendNotification(users, NotificationType.LOAN_STATUS_CHANGED);
+        await sendNotification(users, NotificationType.LOAN_STATUS_CHANGED, true, true, undefined, transaction);
     }
 
     public saveForm = async (

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -3,11 +3,11 @@ import winston, { format } from 'winston';
 import config from '../config';
 
 export const Logger = winston.createLogger({
-    level: config.logs.level,
+    level: process.env.DEBUG === 'true' ? 'debug' : config.logs.level,
     transports: [
         new winston.transports.Console({
             format: format.combine(format.cli(), format.splat()),
-            silent: process.env.NODE_ENV === 'test' // If we're in test mode, we don't want to log to the console
+            silent: process.env.DEBUG === 'true' ? false : process.env.NODE_ENV === 'test' // If we're in test mode, we don't want to log to the console
         })
     ]
 });

--- a/packages/core/src/utils/pushNotification.ts
+++ b/packages/core/src/utils/pushNotification.ts
@@ -6,6 +6,7 @@ import localesConfig from '../utils/locale.json';
 // it needs to be imported this way, or the initialize will fail
 import { AppUser } from '../interfaces/app/appUser';
 import { Logger } from './logger';
+import { Transaction } from 'sequelize';
 import { utils } from '../../index';
 import admin from 'firebase-admin';
 import config from '../config';
@@ -15,7 +16,8 @@ export async function sendNotification(
     type: NotificationType,
     isWallet: boolean = true,
     isWebApp: boolean = true,
-    params?: object
+    params: object | undefined = undefined,
+    transaction: Transaction | undefined = undefined
 ) {
     try {
         // registry notification
@@ -26,7 +28,8 @@ export async function sendNotification(
                 isWallet,
                 isWebApp,
                 params
-            }))
+            })),
+            { transaction }
         );
 
         // filter users that have walletPNT


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR groups transactions by block in order to process them all at once, rather than on each event, generating a lot of commits to the database. Often there are 3~5 events per block, and they can all be group and processed at once. We've tried to do that here https://github.com/impactMarket/backend/pull/737 but it lead to a massive increase in RPC usage and infrastructure.

<img width="1050" alt="image" src="https://github.com/impactMarket/backend/assets/19441097/3616d89c-184c-4336-94c1-89839481beef">


## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
