### PR TITLE
[feature] load and select loan manager to form

### DIFF
--- a/packages/api/src/controllers/v2/microcredit/create.ts
+++ b/packages/api/src/controllers/v2/microcredit/create.ts
@@ -97,10 +97,10 @@ class MicroCreditController {
         }
 
         const form = req.body.form;
-        const { submit, prismicId } = req.body;
+        const { submit, prismicId, selectedLoanManagerId } = req.body;
 
         this.microCreditService
-            .saveForm(req.user.userId, form, prismicId, !!submit)
+            .saveForm(req.user.userId, form, prismicId, selectedLoanManagerId, !!submit)
             .then(community => standardResponse(res, 201, true, community))
             .catch(e => standardResponse(res, 400, false, '', { error: e }));
     };

--- a/packages/api/src/controllers/v2/microcredit/list.ts
+++ b/packages/api/src/controllers/v2/microcredit/list.ts
@@ -110,6 +110,15 @@ class MicroCreditController {
             .then(r => standardResponse(res, 200, true, r))
             .catch(e => standardResponse(res, 400, false, '', { error: e }));
     };
+
+    getLoanManagersByCountry = (req: RequestWithUser, res: Response) => {
+        const country = req.params.country as string;
+
+        this.microCreditService
+            .getLoanManagersByCountry(country)
+            .then(r => standardResponse(res, 200, true, r))
+            .catch(e => standardResponse(res, 400, false, '', { error: e }));
+    };
 }
 
 export { MicroCreditController };

--- a/packages/api/src/controllers/v2/microcredit/list.ts
+++ b/packages/api/src/controllers/v2/microcredit/list.ts
@@ -46,7 +46,7 @@ class MicroCreditController {
             return;
         }
         this.microCreditService
-            .listApplications(req.query)
+            .listApplications(req.user.userId, req.query)
             .then(r => standardResponse(res, 200, true, r))
             .catch(e => standardResponse(res, 400, false, '', { error: e }));
     };

--- a/packages/api/src/routes/v2/microcredit/create.ts
+++ b/packages/api/src/routes/v2/microcredit/create.ts
@@ -141,7 +141,13 @@ export default (route: Router): void => {
      *            properties:
      *              form:
      *                type: object
-     *                required: true
+     *                required: false
+     *              prismicId:
+     *                type: string
+     *                required: false
+     *              selectedLoanManagerId:
+     *                type: number
+     *                required: false
      *              submit:
      *                type: boolean
      *                required: false

--- a/packages/api/src/routes/v2/microcredit/list.ts
+++ b/packages/api/src/routes/v2/microcredit/list.ts
@@ -263,4 +263,26 @@ export default (route: Router): void => {
      *     - BearerToken: []
      */
     route.get('/form/:id', authenticateToken, controller.getUserForm);
+
+    /**
+     * @swagger
+     *
+     * /microcredit/managers/{country}:
+     *   get:
+     *     tags:
+     *       - "microcredit"
+     *     summary: "Get Microcredit managers by country"
+     *     description: "Get Microcredit managers by country"
+     *     parameters:
+     *       - in: path
+     *         name: country
+     *         schema:
+     *           type: string
+     *         required: true
+     *         description: country tag (eg.  NG, KE, GH, etc.)
+     *     responses:
+     *       "200":
+     *         description: OK
+     */
+    route.get('/managers/:country', controller.getLoanManagersByCountry);
 };

--- a/packages/api/src/validators/microcredit.ts
+++ b/packages/api/src/validators/microcredit.ts
@@ -159,9 +159,11 @@ const saveForm = celebrate({
     body: defaultSchema
         .object({
             prismicId: Joi.string().required(),
-            form: Joi.object().required(),
+            form: Joi.object().optional(),
+            selectedLoanManagerId: Joi.number().optional(),
             submit: Joi.bool().optional()
         })
+        .or('selectedLoanManagerId', 'form')
         .required()
 });
 const addNote = celebrate({

--- a/packages/core/src/database/migrations/z20230609115751-create-micro-credit-applications.js
+++ b/packages/core/src/database/migrations/z20230609115751-create-micro-credit-applications.js
@@ -20,11 +20,15 @@ module.exports = {
             },
             form: {
                 type: Sequelize.JSONB,
-                allowNull: false
+                allowNull: true
+            },
+            selectedLoanManagerId: {
+                type: Sequelize.INTEGER,
+                allowNull: true
             },
             prismicId: {
                 type: Sequelize.STRING(32),
-                allowNull: false
+                allowNull: true
             },
             amount: {
                 allowNull: true,

--- a/packages/core/src/database/migrations/z20230725123444-update-microcreditApplication.js
+++ b/packages/core/src/database/migrations/z20230725123444-update-microcreditApplication.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+
+        await queryInterface.addColumn('microcredit_applications', 'selectedLoanManagerId', {
+            type: Sequelize.INTEGER,
+            allowNull: true
+        });
+        await queryInterface.changeColumn('microcredit_applications', 'form', {
+            type: Sequelize.JSONB,
+            allowNull: true
+        });
+        await queryInterface.changeColumn('microcredit_applications', 'prismicId', {
+            type: Sequelize.STRING(32),
+            allowNull: true
+        });
+    },
+    down: (queryInterface) => {},
+};

--- a/packages/core/src/database/models/microCredit/applications.ts
+++ b/packages/core/src/database/models/microCredit/applications.ts
@@ -8,6 +8,7 @@ export class MicroCreditApplicationModel extends Model<MicroCreditApplication, M
     public id!: number;
     public userId!: number;
     public form!: object;
+    public selectedLoanManagerId!: number;
     public prismicId!: string;
     public amount!: number;
     public period!: number;
@@ -41,11 +42,15 @@ export function initializeMicroCreditApplication(sequelize: Sequelize): typeof M
             },
             form: {
                 type: DataTypes.JSONB,
-                allowNull: false
+                allowNull: true
+            },
+            selectedLoanManagerId: {
+                type: DataTypes.INTEGER,
+                allowNull: true
             },
             prismicId: {
                 type: DataTypes.STRING(32),
-                allowNull: false
+                allowNull: true
             },
             amount: {
                 allowNull: true,

--- a/packages/core/src/interfaces/app/appNotification.ts
+++ b/packages/core/src/interfaces/app/appNotification.ts
@@ -39,7 +39,8 @@ export enum NotificationType {
     COMMUNITY_CREATED,
     LOAN_ADDED,
     LEARN_AND_EARN_DO_NEW_LESSON,
-    LOAN_STATUS_CHANGED
+    LOAN_STATUS_CHANGED,
+    NEW_LOAN_SUBMITTED
 }
 
 export interface AppNotification {

--- a/packages/core/src/interfaces/microCredit/applications.ts
+++ b/packages/core/src/interfaces/microCredit/applications.ts
@@ -2,6 +2,7 @@ export interface MicroCreditApplication {
     id: number;
     userId: number;
     form: object;
+    selectedLoanManagerId: number;
     prismicId: string;
     amount: number;
     period: number;
@@ -15,8 +16,9 @@ export interface MicroCreditApplication {
 
 export interface MicroCreditApplicationCreation {
     userId: number;
-    form: object;
-    prismicId: string;
+    form?: object;
+    selectedLoanManagerId?: number;
+    prismicId?: string;
     amount?: number;
     period?: number;
     status?: number;

--- a/packages/core/src/services/microcredit/list.ts
+++ b/packages/core/src/services/microcredit/list.ts
@@ -287,12 +287,15 @@ export default class MicroCreditList {
     };
 
     // read application from models.microCreditApplications, including appUser to include profile
-    public listApplications = async (query: {
-        offset?: number;
-        limit?: number;
-        status?: number;
-        orderBy?: 'appliedOn' | 'appliedOn:asc' | 'appliedOn:desc';
-    }): Promise<{
+    public listApplications = async (
+        userId: number,
+        query: {
+            offset?: number;
+            limit?: number;
+            status?: number;
+            orderBy?: 'appliedOn' | 'appliedOn:asc' | 'appliedOn:desc';
+        }
+    ): Promise<{
         count: number;
         rows: {
             // from models.appUser
@@ -311,7 +314,7 @@ export default class MicroCreditList {
         }[];
     }> => {
         const [orderKey, orderDirection] = query.orderBy ? query.orderBy.split(':') : [undefined, undefined];
-        const where: WhereOptions<MicroCreditApplication> = {};
+        const where: WhereOptions<MicroCreditApplication> = { selectedLoanManagerId: userId };
         if (query.status !== undefined) {
             where.status = query.status;
         } else {

--- a/packages/core/src/services/microcredit/list.ts
+++ b/packages/core/src/services/microcredit/list.ts
@@ -705,4 +705,37 @@ export default class MicroCreditList {
 
         throw new utils.BaseError('NOT_ALLOWED', 'should be a loanManager, councilMember, ambassador or form owner');
     };
+
+    public getLoanManagersByCountry = async (country: string) => {
+        let loanManagers: number[] = [];
+
+        // TODO: this is hardcoded for now, but we should have a better way to do this
+        if (config.jsonRpcUrl.indexOf('alfajores') !== -1) {
+            loanManagers = [5700, 5801];
+        } else {
+            switch (country.toLowerCase()) {
+                case 'br':
+                    loanManagers = [12928, 106251];
+                    break;
+                case 'ug':
+                    loanManagers = [30880, 106251];
+                    break;
+                case 'ng':
+                case 've':
+                    loanManagers = [106251];
+                    break;
+            }
+        }
+
+        const users = await models.appUser.findAll({
+            attributes: ['id', 'address', 'firstName', 'lastName', 'avatarMediaPath'],
+            where: {
+                id: {
+                    [Op.in]: loanManagers
+                }
+            }
+        });
+
+        return users.map(u => u.toJSON());
+    };
 }


### PR DESCRIPTION
This PR fixes #758

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR add functionality to load and select a loan manager.
To load user `GET /microcredit/managers/{country}` where country can be "ug" for Uganda for example. This will load the loan manager profile.
To save the loan manager, the `POST /microcredit/form` was changed. It is now possible to send just the `prismicId` and `selectedLoanManagerId` (which should be the user id from the endpoint above) or the `prismicId` the `from` and `submitted`.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
no new tests