### PR TITLE
[feature] count notifications on user auth/connect

### DIFF
--- a/packages/api/src/controllers/v2/user.ts
+++ b/packages/api/src/controllers/v2/user.ts
@@ -322,23 +322,6 @@ class UserController {
             .catch(e => standardResponse(res, 400, false, '', { error: e.message }));
     };
 
-    public getUnreadNotifications = (req: RequestWithUser, res: Response) => {
-        if (req.user === undefined) {
-            standardResponse(res, 401, false, '', {
-                error: {
-                    name: 'USER_NOT_FOUND',
-                    message: 'User not identified!'
-                }
-            });
-            return;
-        }
-
-        this.userService
-            .getUnreadNotifications(req.user.userId, req.query)
-            .then(r => standardResponse(res, 200, true, r))
-            .catch(e => standardResponse(res, 400, false, '', { error: e.message }));
-    };
-
     public sendPushNotifications = (req: Request, res: Response) => {
         const { country, communities, title, body, data } = req.body;
 

--- a/packages/core/src/services/app/user/index.ts
+++ b/packages/core/src/services/app/user/index.ts
@@ -151,12 +151,17 @@ export default class UserService {
     }
 
     public async get(address: string) {
-        const [user, userRoles, userRules] = await Promise.all([
+        const [user, userRoles, userRules, notificationsCount] = await Promise.all([
             models.appUser.findOne({
                 where: { address }
             }),
             this._userRoles(address),
-            this._userRules(address)
+            this._userRules(address),
+            models.appNotification.count({
+                where: {
+                    read: false
+                }
+            })
         ]);
 
         if (user === null) {
@@ -166,7 +171,8 @@ export default class UserService {
         return {
             ...user.toJSON(),
             ...userRoles,
-            ...userRules
+            ...userRules,
+            notificationsCount
         };
     }
 

--- a/packages/core/src/services/app/user/index.ts
+++ b/packages/core/src/services/app/user/index.ts
@@ -425,23 +425,6 @@ export default class UserService {
         return true;
     }
 
-    public async getUnreadNotifications(
-        userId: number,
-        query: {
-            isWallet?: string;
-            isWebApp?: string;
-        }
-    ): Promise<number> {
-        return models.appNotification.count({
-            where: {
-                userId,
-                read: false,
-                isWebApp: query.isWebApp === 'true',
-                isWallet: query.isWallet === 'true'
-            }
-        });
-    }
-
     public async sendPushNotifications(
         title: string,
         body: string,

--- a/packages/core/src/services/app/user/index.ts
+++ b/packages/core/src/services/app/user/index.ts
@@ -50,6 +50,7 @@ export default class UserService {
             beneficiaryRules?: boolean;
             managerRules?: boolean;
         } = {};
+        let notificationsCount = 0;
 
         // validate to both existing and new accounts
         if (userParams.phone) {
@@ -114,10 +115,15 @@ export default class UserService {
                 return _user;
             };
 
-            [user, userRoles, userRules] = await Promise.all([
+            [user, userRoles, userRules, notificationsCount] = await Promise.all([
                 findAndUpdate(),
                 this._userRoles(userParams.address),
-                this._userRules(userParams.address)
+                this._userRules(userParams.address),
+                models.appNotification.count({
+                    where: {
+                        read: false
+                    }
+                })
             ]);
         }
 
@@ -146,7 +152,8 @@ export default class UserService {
             ...jsonUser,
             ...userRoles,
             ...userRules,
-            token
+            token,
+            notificationsCount
         };
     }
 

--- a/packages/core/tests/integration/v2/user.test.ts
+++ b/packages/core/tests/integration/v2/user.test.ts
@@ -618,7 +618,7 @@ describe('user service v2', () => {
                 user.id
             );
 
-            expect(notifications).to.be.eq(1);
+            expect(notifications.count).to.be.eq(1);
         });
     });
 

--- a/packages/core/tests/integration/v2/user.test.ts
+++ b/packages/core/tests/integration/v2/user.test.ts
@@ -610,10 +610,13 @@ describe('user service v2', () => {
                 type: 0,
                 userId: user.id
             });
-            const notifications = await userService.getNotifications({
-                isWebApp: true,
-                unreadOnly: true
-            }, user.id);
+            const notifications = await userService.getNotifications(
+                {
+                    isWebApp: true,
+                    unreadOnly: true
+                },
+                user.id
+            );
 
             expect(notifications).to.be.eq(1);
         });

--- a/packages/core/tests/integration/v2/user.test.ts
+++ b/packages/core/tests/integration/v2/user.test.ts
@@ -610,9 +610,10 @@ describe('user service v2', () => {
                 type: 0,
                 userId: user.id
             });
-            const notifications = await userService.getUnreadNotifications(user.id, {
-                isWebApp: 'true'
-            });
+            const notifications = await userService.getNotifications({
+                isWebApp: true,
+                unreadOnly: true
+            }, user.id);
 
             expect(notifications).to.be.eq(1);
         });


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR adds a `notificationsCount` to GET /users and POST /users, so we can quickly load the number of notifications a user has that are not read.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
