### PR TITLE
[bugfix] community metrics

### DIFF
--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -43,7 +43,11 @@ const models = sequelize.models as DbModels;
 let redisClient: Redis = undefined as any;
 
 if (process.env.NODE_ENV !== 'test') {
-    redisClient = new Redis(config.redis);
+    redisClient = new Redis(config.redis, {
+        tls: {
+            rejectUnauthorized: false
+        }
+    });
 }
 
 export { sequelize, Sequelize, models, redisClient };

--- a/packages/core/src/subgraph/config.ts
+++ b/packages/core/src/subgraph/config.ts
@@ -28,17 +28,20 @@ const axiosMicrocreditSubgraph = axios.create({
 axiosRetry(axiosSubgraph as any, {
     retries: 3,
     retryDelay: axiosRetry.exponentialDelay,
-    retryCondition: _error => true // retry regardless of the error
+    retryCondition: _error => true, // retry regardless of the error
+    shouldResetTimeout: true
 });
 axiosRetry(axiosCouncilSubgraph as any, {
     retries: 3,
     retryDelay: axiosRetry.exponentialDelay,
-    retryCondition: _error => true
+    retryCondition: _error => true,
+    shouldResetTimeout: true
 });
 axiosRetry(axiosMicrocreditSubgraph as any, {
     retries: 3,
     retryDelay: axiosRetry.exponentialDelay,
-    retryCondition: _error => true
+    retryCondition: _error => true,
+    shouldResetTimeout: true
 });
 
 export { axiosSubgraph, axiosCouncilSubgraph, axiosMicrocreditSubgraph };


### PR DESCRIPTION
no task.

## Changes
Update Redis client, adding the option `tls` and the axios-retry, adding the option `shouldResetTimeout`.

> Unless `shouldResetTimeout` is set, the plugin interprets the request timeout as a global value, so it is not used for each retry but for the whole request lifecycle.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
