### PR TITLE
[bugfix] fix L&E webhook

### DIFF
--- a/packages/core/src/services/learnAndEarn/syncRemote.ts
+++ b/packages/core/src/services/learnAndEarn/syncRemote.ts
@@ -50,7 +50,7 @@ async function getPrismicLearnAndEarn() {
                 // update reward
                 await models.learnAndEarnLevel.update(
                     {
-                        totalReward: prismicLevel.data.reward
+                        totalReward: prismicLevel.data.reward || 0
                     },
                     {
                         where: {


### PR DESCRIPTION
no task.

## Changes
Set 0 if the level reward is empty on prismic.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
