### PR TITLE
[bugfix] prevent changing application loan to invalid status

### DIFF
--- a/packages/core/src/interfaces/microCredit/applications.ts
+++ b/packages/core/src/interfaces/microCredit/applications.ts
@@ -32,5 +32,6 @@ export enum MicroCreditApplicationStatus {
     REQUEST_CHANGES = 3,
     INTERVIEW = 4,
     APPROVED = 5,
-    REJECTED = 6
+    REJECTED = 6,
+    CANCELED = 10
 }


### PR DESCRIPTION
This PR add a protection against setting invalid status of an application loan, such as, change status after approved (unless it is to cancel) or after being canceled

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
