### PR TITLE
prevent error if borrower does not have loans yet

### DIFF
--- a/packages/core/src/subgraph/queries/microcredit.ts
+++ b/packages/core/src/subgraph/queries/microcredit.ts
@@ -300,7 +300,7 @@ export const getBorrowerRepayments = async (query: {
     >('', graphqlQuery);
 
     const repaymentsAndCount = {
-        count: response.data?.data.borrower.repaymentsCount,
+        count: response.data?.data.borrower?.repaymentsCount || 0,
         rows: response.data?.data.repayments.map((repayment: any) => ({
             amount: parseFloat(repayment.amount),
             debt: parseFloat(repayment.debt),


### PR DESCRIPTION
This PR fixes query when the borrower still has no loan. This endpoint is requested by loan manager and the borrower.

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
