### PR TITLE
[bugfix] prevent user age from being erased

### DIFF
--- a/packages/api/src/controllers/v2/user.ts
+++ b/packages/api/src/controllers/v2/user.ts
@@ -143,14 +143,14 @@ class UserController {
                 appPNT,
                 firstName,
                 lastName,
-                year: age ? new Date().getUTCFullYear() - age : null,
                 children,
                 avatarMediaPath,
                 email,
                 gender,
                 bio,
                 country,
-                phone
+                phone,
+                ...(age && { year: new Date().getUTCFullYear() - age })
             })
             .then(user =>
                 standardResponse(res, 200, true, {


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR fixes the issue when a user updates any profile parameter but not the age, erasing the age by consequence.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
