### PR TITLE
[fix] - save last block on recover events

### DIFF
--- a/packages/core/src/subscriber/chainSubscribers.ts
+++ b/packages/core/src/subscriber/chainSubscribers.ts
@@ -109,6 +109,7 @@ class ChainSubscribers {
                     transactions.push(this._filterAndProcessEvent(logs[x], t));
                 }
                 await Promise.all(transactions);
+                database.redisClient.set('lastBlock', logs[logs.length - 1].blockNumber);
                 services.app.ImMetadataService.setLastBlock(logs[logs.length - 1].blockNumber);
             });
         } catch (error) {


### PR DESCRIPTION
no task.

## Changes
At the end of the recover events, save the lastblock in the cache

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
