### PR TITLE
[feature] add support to cashout individuals

### DIFF
--- a/packages/api/src/controllers/v2/cico/index.ts
+++ b/packages/api/src/controllers/v2/cico/index.ts
@@ -10,7 +10,8 @@ const { CICOProviderService } = services.app;
 export const getCICO = (req: Request & ValidatedRequest<ListCICOProviderRequestSchema>, res: Response) => {
     const cicoProviderService = new CICOProviderService();
 
-    cicoProviderService.get(req.query)
+    cicoProviderService
+        .get(req.query)
         .then(r => standardResponse(res, 200, true, r, {}))
         .catch(e => standardResponse(res, 400, false, '', { error: e.message }));
 };

--- a/packages/api/src/controllers/v2/cico/index.ts
+++ b/packages/api/src/controllers/v2/cico/index.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { services } from '@impactmarket/core';
+
+import { ListCICOProviderRequestSchema } from '~validators/cico';
+import { ValidatedRequest } from '~utils/queryValidator';
+import { standardResponse } from '~utils/api';
+
+const { CICOProviderService } = services.app;
+
+export const getCICO = (req: Request & ValidatedRequest<ListCICOProviderRequestSchema>, res: Response) => {
+    const cicoProviderService = new CICOProviderService();
+
+    cicoProviderService.get(req.query)
+        .then(r => standardResponse(res, 200, true, r, {}))
+        .catch(e => standardResponse(res, 400, false, '', { error: e.message }));
+};

--- a/packages/api/src/routes/v2/cico/index.ts
+++ b/packages/api/src/routes/v2/cico/index.ts
@@ -1,0 +1,48 @@
+import { Router } from 'express';
+
+import { getCICO } from '~controllers/v2/cico';
+import { listCICOProviderValidator } from '~validators/cico';
+
+export default (app: Router): void => {
+    const route = Router();
+    app.use('/cico', route);
+
+    /**
+     * @swagger
+     *
+     * /cico:
+     *   get:
+     *     tags:
+     *       - "cico"
+     *     summary: Get cash-in/cash-out providers
+     *     parameters:
+     *       - in: query
+     *         name: country
+     *         schema:
+     *           type: string
+     *         required: false
+     *         description: filter by country
+     *       - in: query
+     *         name: lat
+     *         schema:
+     *           type: number
+     *         required: false
+     *         description: latitude used for nearest location
+     *       - in: query
+     *         name: lng
+     *         schema:
+     *           type: number
+     *         required: false
+     *         description: longitude used for nearest location
+     *       - in: query
+     *         name: distance
+     *         schema:
+     *           type: number
+     *         required: false
+     *         description: distance in kilometers between the user location and providers
+     *     responses:
+     *       "200":
+     *         description: OK
+     */
+    route.get('/:query?', listCICOProviderValidator, getCICO);
+};

--- a/packages/api/src/routes/v2/index.ts
+++ b/packages/api/src/routes/v2/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 
 import attestation from './attestation';
+import cico from './cico';
 import claimLocation from './claimLocation';
 import community from './community';
 import generic from './generic';
@@ -25,6 +26,7 @@ export default (): Router => {
     microcredit(app);
     protocol(app);
     referrals(app);
+    cico(app);
 
     return app;
 };

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -63,6 +63,10 @@ export default (app: express.Application): void => {
                             'MicroCredit endpoints. In this section, all endpoints are protected by authentication and signature verification. Be sure to be properly authenticated!'
                     },
                     {
+                        name: 'learn-and-earn',
+                        description: 'Learn and Earn'
+                    },
+                    {
                         name: 'referrals',
                         description: 'impactMarket referral program!'
                     }

--- a/packages/api/src/validators/cico.ts
+++ b/packages/api/src/validators/cico.ts
@@ -1,0 +1,31 @@
+import { Joi } from 'celebrate';
+
+import { ContainerTypes, ValidatedRequestSchema, createValidator } from '../utils/queryValidator';
+import { defaultSchema } from './defaultSchema';
+
+const validator = createValidator();
+
+type ListCICOProviderType = {
+    country?: string;
+    lat?: number;
+    lng?: number;
+    distance?: number;
+};
+
+const queryListBorrowersSchema = defaultSchema.object<ListCICOProviderType>({
+    country: Joi.string().optional(),
+    lat: Joi.number().optional(),
+    lng: Joi.number().optional(),
+    distance: Joi.number().optional(),
+});
+
+interface ListCICOProviderRequestSchema extends ValidatedRequestSchema {
+    [ContainerTypes.Query]: ListCICOProviderType;
+}
+
+const listCICOProviderValidator = validator.query(queryListBorrowersSchema);
+
+export {
+    listCICOProviderValidator,
+    ListCICOProviderRequestSchema,
+};

--- a/packages/api/src/validators/cico.ts
+++ b/packages/api/src/validators/cico.ts
@@ -16,7 +16,7 @@ const queryListBorrowersSchema = defaultSchema.object<ListCICOProviderType>({
     country: Joi.string().optional(),
     lat: Joi.number().optional(),
     lng: Joi.number().optional(),
-    distance: Joi.number().optional(),
+    distance: Joi.number().optional()
 });
 
 interface ListCICOProviderRequestSchema extends ValidatedRequestSchema {
@@ -25,7 +25,4 @@ interface ListCICOProviderRequestSchema extends ValidatedRequestSchema {
 
 const listCICOProviderValidator = validator.query(queryListBorrowersSchema);
 
-export {
-    listCICOProviderValidator,
-    ListCICOProviderRequestSchema,
-};
+export { listCICOProviderValidator, ListCICOProviderRequestSchema };

--- a/packages/core/src/database/db.ts
+++ b/packages/core/src/database/db.ts
@@ -3,6 +3,7 @@ import { ModelStatic, Sequelize } from 'sequelize/types';
 import { AirgrabProofModel } from './models/airgrab/airgrabProof';
 import { AirgrabUserModel } from './models/airgrab/airgrabUser';
 import { AppAnonymousReportModel } from './models/app/anonymousReport';
+import { AppCICOProviderModel } from './models/cico/providers';
 import { AppClientCredentialModel } from './models/app/appClientCredential';
 import { AppExchangeRates } from './models/app/exchangeRates';
 import { AppLogModel } from './models/app/appLog';
@@ -70,6 +71,7 @@ export type DbModels = {
     appUserValidationCode: ModelStatic<AppUserValidationCodeModel>;
     ubiBeneficiarySurvey: ModelStatic<UbiBeneficiarySurveyModel>;
     appReferralCode: ModelStatic<AppReferralCodeModel>;
+    appCICOProvider: ModelStatic<AppCICOProviderModel>;
     //
     community: ModelStatic<Community>;
     ubiCommunitySuspect: ModelStatic<UbiCommunitySuspectModel>;

--- a/packages/core/src/database/migrations/z20230920145533-create-cico-provider.js
+++ b/packages/core/src/database/migrations/z20230920145533-create-cico-provider.js
@@ -1,0 +1,48 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable('app_cico_provider', {
+            id: {
+                type: Sequelize.INTEGER,
+                autoIncrement: true,
+                primaryKey: true
+            },
+            name: {
+                type: Sequelize.STRING(64),
+                allowNull: false
+            },
+            description: {
+                type: Sequelize.STRING(256),
+                allowNull: false
+            },
+            countries: {
+                type: Sequelize.ARRAY(Sequelize.STRING(2)),
+                allowNull: false
+            },
+            type: {
+                type: Sequelize.INTEGER,
+                allowNull: false
+            },
+            isCashin: {
+                type: Sequelize.BOOLEAN,
+                allowNull: false
+            },
+            isCashout: {
+                type: Sequelize.BOOLEAN,
+                allowNull: false
+            },
+            details: {
+                type: Sequelize.JSONB,
+                allowNull: false
+            },
+            updatedAt: {
+                type: Sequelize.DATE,
+                allowNull: false
+            }
+        });
+    },
+    async down(queryInterface, Sequelize) {
+        await queryInterface.dropTable('app_cico_provider');
+    }
+};

--- a/packages/core/src/database/models/cico/providers.ts
+++ b/packages/core/src/database/models/cico/providers.ts
@@ -8,7 +8,7 @@ type ExchangeDetails = {
     website?: string;
     customImplementation?: string;
     iframeUrl?: string;
-}
+};
 
 type MerchantDetails = {
     category: number;
@@ -23,7 +23,7 @@ type MerchantDetails = {
         longitude: number;
     };
     payment: boolean;
-}
+};
 
 type IndividualDetails = {
     category: number;

--- a/packages/core/src/database/models/cico/providers.ts
+++ b/packages/core/src/database/models/cico/providers.ts
@@ -1,0 +1,123 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+
+type ExchangeDetails = {
+    fee: number;
+    min?: number;
+    max?: number;
+    logoUrl?: string;
+    website?: string;
+    customImplementation?: string;
+    iframeUrl?: string;
+}
+
+type MerchantDetails = {
+    category: number;
+    fee: number;
+    min?: number;
+    max?: number;
+    // it's maps address, not wallet address
+    address: string;
+    phone: string;
+    gps: {
+        latitude: number;
+        longitude: number;
+    };
+    payment: boolean;
+}
+
+type IndividualDetails = {
+    category: number;
+    fee: number;
+    min?: number;
+    max?: number;
+    phone: string;
+};
+
+export interface CICOProviderRegistry {
+    id: number;
+    name: string;
+    description: string;
+    countries: string[];
+    type: number;
+    isCashin: boolean;
+    isCashout: boolean;
+    details: ExchangeDetails | MerchantDetails | IndividualDetails;
+
+    updatedAt: Date;
+}
+
+export interface CICOProviderRegistryCreation {
+    name: string;
+    description: string;
+    countries: string[];
+    type: number;
+    isCashin: boolean;
+    isCashout: boolean;
+    details: ExchangeDetails | MerchantDetails | IndividualDetails;
+}
+
+export class AppCICOProviderModel extends Model<CICOProviderRegistry, CICOProviderRegistryCreation> {
+    public id!: number;
+    public name!: string;
+    public description!: string;
+    public countries!: string[];
+    // 0 - exchange, 1 - merchant, 2 - individual
+    public type!: number;
+    public isCashin!: boolean;
+    public isCashout!: boolean;
+    public details!: ExchangeDetails | MerchantDetails | IndividualDetails;
+
+    // timestamps!
+    public updatedAt!: Date;
+}
+
+export function initializeAppCICOProvider(sequelize: Sequelize): typeof AppCICOProviderModel {
+    AppCICOProviderModel.init(
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                autoIncrement: true,
+                primaryKey: true
+            },
+            name: {
+                type: DataTypes.STRING(64),
+                allowNull: false
+            },
+            description: {
+                type: DataTypes.STRING(256),
+                allowNull: false
+            },
+            countries: {
+                type: DataTypes.ARRAY(DataTypes.STRING(2)),
+                allowNull: false
+            },
+            type: {
+                type: DataTypes.INTEGER,
+                allowNull: false
+            },
+            isCashin: {
+                type: DataTypes.BOOLEAN,
+                allowNull: false
+            },
+            isCashout: {
+                type: DataTypes.BOOLEAN,
+                allowNull: false
+            },
+            details: {
+                type: DataTypes.JSONB,
+                allowNull: false
+            },
+            updatedAt: {
+                type: DataTypes.DATE,
+                allowNull: false
+            }
+        },
+        {
+            tableName: 'app_cico_provider',
+            modelName: 'appCICOProvider',
+            sequelize,
+            createdAt: false
+        }
+    );
+    return AppCICOProviderModel;
+}

--- a/packages/core/src/database/models/index.ts
+++ b/packages/core/src/database/models/index.ts
@@ -4,6 +4,7 @@ import { communityAssociation } from './associations/community';
 import { initializeAirgrabProof } from './airgrab/airgrabProof';
 import { initializeAirgrabUser } from './airgrab/airgrabUser';
 import { initializeAppAnonymousReport } from './app/anonymousReport';
+import { initializeAppCICOProvider } from './cico/providers';
 import { initializeAppClientCredential } from './app/appClientCredential';
 import { initializeAppExchangeRates } from './app/exchangeRates';
 import { initializeAppLog } from './app/appLog';
@@ -76,6 +77,7 @@ export default function initModels(sequelize: Sequelize): void {
     initializeAppLog(sequelize);
     initializeAppUserValidationCode(sequelize);
     initializeAppReferralCode(sequelize);
+    initializeAppCICOProvider(sequelize);
 
     // ubi
     initializeCommunity(sequelize);

--- a/packages/core/src/services/app/cicoProvider.ts
+++ b/packages/core/src/services/app/cicoProvider.ts
@@ -1,0 +1,126 @@
+import { Op, WhereOptions } from 'sequelize';
+
+import { AppCICOProviderModel, CICOProviderRegistry } from '../../database/models/cico/providers';
+import { models, sequelize } from '../../database';
+
+export default class CICOProviderService {
+    public async get(query: { country?: string; lat?: string; lng?: string; distance?: string }) {
+        let rawMerchants: AppCICOProviderModel[] | null = null;
+        let rawIndividuals: AppCICOProviderModel[] | null = null;
+        let merchants: CICOProviderRegistry[] | null = null;
+
+        // when no query is provided
+        if (!query || (!query.country && !query.lat && !query.lng)) {
+            rawMerchants = await models.appCICOProvider.findAll({
+                where: {
+                    type: 1
+                },
+                limit: 5,
+                order: [['createdAt', 'DESC']]
+            });
+            rawIndividuals = await models.appCICOProvider.findAll({
+                where: {
+                    type: 2
+                },
+                limit: 5,
+                order: [['createdAt', 'DESC']]
+            });
+            const exchanges = await models.appCICOProvider.findAll({
+                where: {
+                    type: 0,
+                    countries: {
+                        [Op.contains]: ['all']
+                    }
+                },
+                limit: 5,
+                order: [['createdAt', 'DESC']]
+            });
+
+            return {
+                merchants: rawMerchants.map(m => m.toJSON()),
+                individuals: rawIndividuals.map(i => i.toJSON()),
+                exchanges: exchanges.map(e => e.toJSON())
+            };
+        }
+
+        let exchangesWhere: WhereOptions<AppCICOProviderModel> = {
+            countries: {
+                [Op.contains]: ['all']
+            }
+        };
+
+        // when country is provided
+        if (query.country) {
+            exchangesWhere = {
+                countries: {
+                    [Op.contains]: [query.country, 'all']
+                }
+            };
+
+            rawMerchants = await models.appCICOProvider.findAll({
+                where: {
+                    countries: {
+                        [Op.contains]: [query.country]
+                    }
+                }
+            });
+            if (!query.lat && !query.lng) {
+                merchants = rawMerchants.map(merchant => merchant.toJSON());
+            }
+        }
+
+        const exchanges = await models.appCICOProvider.findAll({
+            where: exchangesWhere,
+            order: ['countries']
+        });
+
+        // when lat and lng are provided
+        if (query.lat && query.lng) {
+            if (!rawMerchants) {
+                rawMerchants = await models.appCICOProvider.findAll({
+                    attributes: [
+                        [
+                            sequelize.literal(
+                                '3959 * acos(cos(radians(' +
+                                    parseFloat(query.lat) +
+                                    ")) * cos(radians(details->'gps'->>'latitude')) * cos(radians(" +
+                                    parseFloat(query.lng) +
+                                    ") - radians(details->'gps'->>'longitude')) + sin(radians(" +
+                                    parseFloat(query.lat) +
+                                    ")) * sin(radians(details->'gps'->>'latitude')))"
+                            ),
+                            'distance'
+                        ],
+                        'id',
+                        'name',
+                        'description',
+                        'countries',
+                        'isCashin',
+                        'isCashout',
+                        'details'
+                    ],
+                    having: sequelize.literal('distance < 20'),
+                    order: sequelize.literal('distance ASC'),
+                    where: {
+                        type: 1
+                    }
+                });
+            }
+
+            merchants = rawMerchants.map(merchant => merchant.toJSON());
+        }
+
+        rawIndividuals = await models.appCICOProvider.findAll({
+            where: {
+                type: 2
+            },
+            order: [['createdAt', 'DESC']]
+        });
+
+        return {
+            exchanges,
+            merchants,
+            individuals: rawIndividuals.map(i => i.toJSON())
+        };
+    }
+}

--- a/packages/core/src/services/app/cicoProvider.ts
+++ b/packages/core/src/services/app/cicoProvider.ts
@@ -1,126 +1,154 @@
-import { Op, WhereOptions } from 'sequelize';
+import { Op, QueryTypes, WhereOptions } from 'sequelize';
 
 import { AppCICOProviderModel, CICOProviderRegistry } from '../../database/models/cico/providers';
 import { models, sequelize } from '../../database';
 
-export default class CICOProviderService {
-    public async get(query: { country?: string; lat?: string; lng?: string; distance?: string }) {
-        let rawMerchants: AppCICOProviderModel[] | null = null;
-        let rawIndividuals: AppCICOProviderModel[] | null = null;
-        let merchants: CICOProviderRegistry[] | null = null;
+enum CICOProviderType {
+    EXCHANGE = 0,
+    MERCHANT = 1,
+    INDIVIDUAL = 2
+}
 
+export default class CICOProviderService {
+    public async get(query: { country?: string; lat?: number; lng?: number; distance?: number }) {
         // when no query is provided
-        if (!query || (!query.country && !query.lat && !query.lng)) {
-            rawMerchants = await models.appCICOProvider.findAll({
+        if (!query.country && !query.lat && !query.lng && !query.distance) {
+            console.log('default query');
+            const { rows: merchantsRows, count: merchantsCount } = await models.appCICOProvider.findAndCountAll({
                 where: {
-                    type: 1
+                    type: CICOProviderType.MERCHANT
                 },
                 limit: 5,
-                order: [['createdAt', 'DESC']]
+                order: [['updatedAt', 'DESC']]
             });
-            rawIndividuals = await models.appCICOProvider.findAll({
+            const { rows: individualsRows, count: individualsCount } = await models.appCICOProvider.findAndCountAll({
                 where: {
-                    type: 2
+                    type: CICOProviderType.INDIVIDUAL
                 },
                 limit: 5,
-                order: [['createdAt', 'DESC']]
+                order: [['updatedAt', 'DESC']]
             });
-            const exchanges = await models.appCICOProvider.findAll({
+            const { rows: exchangesRows, count: exchangesCount } = await models.appCICOProvider.findAndCountAll({
                 where: {
-                    type: 0,
+                    type: CICOProviderType.EXCHANGE,
                     countries: {
-                        [Op.contains]: ['all']
+                        [Op.contains]: ['11']
                     }
                 },
                 limit: 5,
-                order: [['createdAt', 'DESC']]
+                order: [['updatedAt', 'DESC']]
             });
 
             return {
-                merchants: rawMerchants.map(m => m.toJSON()),
-                individuals: rawIndividuals.map(i => i.toJSON()),
-                exchanges: exchanges.map(e => e.toJSON())
+                merchants: {
+                    rows: merchantsRows.map(m => m.toJSON()),
+                    count: merchantsCount
+                },
+                individuals: {
+                    rows: individualsRows.map(i => i.toJSON()),
+                    count: individualsCount
+                },
+                exchanges: {
+                    rows: exchangesRows.map(e => e.toJSON()),
+                    count: exchangesCount
+                }
             };
         }
 
+        let merchantsRows: CICOProviderRegistry[] = [];
+        let merchantsCount: number = 0;
+        let individualsRows: AppCICOProviderModel[] = [];
+        let individualsCount: number = 0;
+
         let exchangesWhere: WhereOptions<AppCICOProviderModel> = {
+            type: CICOProviderType.EXCHANGE,
             countries: {
-                [Op.contains]: ['all']
+                [Op.contains]: ['11']
             }
         };
 
         // when country is provided
         if (query.country) {
             exchangesWhere = {
+                type: CICOProviderType.EXCHANGE,
                 countries: {
-                    [Op.contains]: [query.country, 'all']
+                    [Op.or]: [{ [Op.contains]: [query.country] }, { [Op.contains]: ['11'] }]
                 }
             };
 
-            rawMerchants = await models.appCICOProvider.findAll({
+            if (!query.lat && !query.lng) {
+                const merchantsResponse = await models.appCICOProvider.findAndCountAll({
+                    where: {
+                        type: CICOProviderType.MERCHANT,
+                        countries: {
+                            [Op.contains]: [query.country]
+                        }
+                    }
+                });
+                merchantsRows = merchantsResponse.rows.map(m => m.toJSON());
+                merchantsCount = merchantsResponse.count;
+            }
+
+            const individualsResponse = await models.appCICOProvider.findAndCountAll({
                 where: {
+                    type: CICOProviderType.INDIVIDUAL,
                     countries: {
                         [Op.contains]: [query.country]
                     }
-                }
+                },
+                order: [['updatedAt', 'DESC']]
             });
-            if (!query.lat && !query.lng) {
-                merchants = rawMerchants.map(merchant => merchant.toJSON());
-            }
+            individualsRows = individualsResponse.rows;
+            individualsCount = individualsResponse.count;
         }
 
-        const exchanges = await models.appCICOProvider.findAll({
+        const { rows: exchangesRows, count: exchangesCount } = await models.appCICOProvider.findAndCountAll({
             where: exchangesWhere,
             order: ['countries']
         });
 
         // when lat and lng are provided
         if (query.lat && query.lng) {
-            if (!rawMerchants) {
-                rawMerchants = await models.appCICOProvider.findAll({
-                    attributes: [
-                        [
-                            sequelize.literal(
-                                '3959 * acos(cos(radians(' +
-                                    parseFloat(query.lat) +
-                                    ")) * cos(radians(details->'gps'->>'latitude')) * cos(radians(" +
-                                    parseFloat(query.lng) +
-                                    ") - radians(details->'gps'->>'longitude')) + sin(radians(" +
-                                    parseFloat(query.lat) +
-                                    ")) * sin(radians(details->'gps'->>'latitude')))"
-                            ),
-                            'distance'
-                        ],
-                        'id',
-                        'name',
-                        'description',
-                        'countries',
-                        'isCashin',
-                        'isCashout',
-                        'details'
-                    ],
-                    having: sequelize.literal('distance < 20'),
-                    order: sequelize.literal('distance ASC'),
-                    where: {
-                        type: 1
-                    }
-                });
-            }
-
-            merchants = rawMerchants.map(merchant => merchant.toJSON());
+            // it needs to be this way, so we can filter by distance
+            // if we didn't need that distance filter, we could use sequelize regular query
+            const rawResponse = await sequelize.query(
+                `
+                SELECT
+                    a.distance,
+                    app_cico_provider.*
+                FROM
+                    (SELECT id, (
+                        6371 *
+                        acos(cos(radians(${query.lat})) *
+                        cos(radians(cast(details->'gps'->>'latitude' as float))) *
+                        cos(radians(${query.lng}) -
+                            radians(cast(details->'gps'->>'longitude' as float))) +
+                        sin(radians(${query.lat})) *
+                        sin(radians(cast(details->'gps'->>'latitude' as float))))
+                    ) AS "distance" from app_cico_provider) as a,
+                    app_cico_provider
+                WHERE a."distance" < ${query.distance || 100}
+                    and a.id = app_cico_provider.id
+                    and type = ${CICOProviderType.MERCHANT}`.replaceAll(/\n {2,}/g, ' '),
+                { type: QueryTypes.SELECT }
+            );
+            merchantsRows = rawResponse as unknown[] as CICOProviderRegistry[];
+            merchantsCount = rawResponse.length;
         }
 
-        rawIndividuals = await models.appCICOProvider.findAll({
-            where: {
-                type: 2
-            },
-            order: [['createdAt', 'DESC']]
-        });
-
         return {
-            exchanges,
-            merchants,
-            individuals: rawIndividuals.map(i => i.toJSON())
+            exchanges: {
+                rows: exchangesRows.map(e => e.toJSON()),
+                count: exchangesCount
+            },
+            merchants: {
+                rows: merchantsRows,
+                count: merchantsCount
+            },
+            individuals: {
+                rows: individualsRows.map(i => i.toJSON()),
+                count: individualsCount
+            }
         };
     }
 }

--- a/packages/core/src/services/app/index.ts
+++ b/packages/core/src/services/app/index.ts
@@ -1,4 +1,5 @@
+import CICOProviderService from './cicoProvider';
 import CashoutProviderService from './cashoutProvider';
 import ImMetadataService from './imMetadata';
 
-export { ImMetadataService, CashoutProviderService };
+export { ImMetadataService, CashoutProviderService, CICOProviderService };


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR replaces creates a new table, called app_cico_provider, which replaces exchange_registry and merchange_registry, putting everything in a single table together with individuals now. The two prior tables need to be removed later (not now to avoid breaking the app).

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
