### PR TITLE
[feature] recurring donations

### DIFF
--- a/packages/api/src/controllers/v2/lazyAgenda.ts
+++ b/packages/api/src/controllers/v2/lazyAgenda.ts
@@ -1,0 +1,48 @@
+import { Response } from 'express';
+import { services } from '@impactmarket/core';
+
+import { AddUserLazyAgendaItem } from '~validators/lazyAgenda';
+import { RequestWithUser } from '~middlewares/core';
+import { standardResponse } from '~utils/api';
+
+class LazyAgendaController {
+    private lazyAgendaService: services.app.LazyAgendaService;
+    constructor() {
+        this.lazyAgendaService = new services.app.LazyAgendaService();
+    }
+
+    get = (req: RequestWithUser, res: Response) => {
+        if (req.user === undefined) {
+            standardResponse(res, 401, false, '', {
+                error: {
+                    name: 'USER_NOT_FOUND',
+                    message: 'User not identified!'
+                }
+            });
+            return;
+        }
+        this.lazyAgendaService
+            .get(req.user.userId)
+            .then(r => standardResponse(res, 200, true, r))
+            .catch(e => standardResponse(res, 400, false, '', { error: e }));
+    };
+
+    add = (req: RequestWithUser<any, any, AddUserLazyAgendaItem>, res: Response) => {
+        if (req.user === undefined) {
+            standardResponse(res, 401, false, '', {
+                error: {
+                    name: 'USER_NOT_FOUND',
+                    message: 'User not identified!'
+                }
+            });
+            return;
+        }
+
+        this.lazyAgendaService
+            .add({ userId: req.user.userId, ...req.body })
+            .then(r => standardResponse(res, 200, true, r))
+            .catch(e => standardResponse(res, 400, false, '', { error: e }));
+    };
+}
+
+export { LazyAgendaController };

--- a/packages/api/src/controllers/v2/lazyAgenda.ts
+++ b/packages/api/src/controllers/v2/lazyAgenda.ts
@@ -43,6 +43,23 @@ class LazyAgendaController {
             .then(r => standardResponse(res, 200, true, r))
             .catch(e => standardResponse(res, 400, false, '', { error: e }));
     };
+
+    delete = (req: RequestWithUser<{ id: string }, any, any>, res: Response) => {
+        if (req.user === undefined) {
+            standardResponse(res, 401, false, '', {
+                error: {
+                    name: 'USER_NOT_FOUND',
+                    message: 'User not identified!'
+                }
+            });
+            return;
+        }
+
+        this.lazyAgendaService
+            .delete(req.user.userId, parseInt(req.params.id, 10))
+            .then(r => standardResponse(res, 200, true, r))
+            .catch(e => standardResponse(res, 400, false, '', { error: e }));
+    };
 }
 
 export { LazyAgendaController };

--- a/packages/api/src/controllers/v2/learnAndEarn.ts
+++ b/packages/api/src/controllers/v2/learnAndEarn.ts
@@ -3,12 +3,11 @@ import {
     ListLevelsRequestType,
     RegisterClaimRewardsRequestType,
     StartLessonRequestType
-} from '../../validators/learnAndEarn';
+} from '~validators/learnAndEarn';
 import { Request, Response } from 'express';
+import { RequestWithUser } from '~middlewares/core';
 import { config, services } from '@impactmarket/core';
-
-import { RequestWithUser } from '../../middlewares/core';
-import { standardResponse } from '../../utils/api';
+import { standardResponse } from '~utils/api';
 
 class LearnAndEarnController {
     total = (req: RequestWithUser, res: Response) => {

--- a/packages/api/src/routes/v2/index.ts
+++ b/packages/api/src/routes/v2/index.ts
@@ -6,6 +6,7 @@ import claimLocation from './claimLocation';
 import community from './community';
 import generic from './generic';
 import global from './global';
+import lazyAgenda from './lazyAgenda';
 import learnAndEarn from './learnAndEarn';
 import microcredit from './microcredit';
 import protocol from './protocol';
@@ -27,6 +28,7 @@ export default (): Router => {
     protocol(app);
     referrals(app);
     cico(app);
+    lazyAgenda(app);
 
     return app;
 };

--- a/packages/api/src/routes/v2/lazyAgenda.ts
+++ b/packages/api/src/routes/v2/lazyAgenda.ts
@@ -22,8 +22,10 @@ export default (app: Router): void => {
      *         description: "Success"
      *       "403":
      *         description: "Invalid input"
+     *     security:
+     *     - BearerToken: []
      */
-    route.get('/', controller.get);
+    route.get('/', authenticateToken, controller.get);
 
     /**
      * @swagger
@@ -43,12 +45,15 @@ export default (app: Router): void => {
      *              type:
      *                type: number
      *                required: true
+     *                example: 0
      *              details:
      *                type: object
      *                required: false
+     *                example: { "amount": 5 }
      *              frequency:
      *                type: number
      *                required: true
+     *                example: 2592000
      *     responses:
      *       "200":
      *         description: "Success"
@@ -58,4 +63,29 @@ export default (app: Router): void => {
      *     - BearerToken: []
      */
     route.post('/', authenticateToken, addUserLazyAgendaItemValidator, controller.add);
+
+    /**
+     * @swagger
+     *
+     * /lazy-agenda/{id}:
+     *   delete:
+     *     tags:
+     *     - "lazy-agenda"
+     *     summary: "Delete a lazy agenda item"
+     *     parameters:
+     *       - in: path
+     *         name: id
+     *         schema:
+     *           type: integer
+     *         required: true
+     *         description: Lazy agenda item id to remove
+     *     responses:
+     *       "200":
+     *         description: "Success"
+     *       "403":
+     *         description: "Invalid input"
+     *     security:
+     *     - BearerToken: []
+     */
+    route.delete('/:id', authenticateToken, controller.delete);
 };

--- a/packages/api/src/routes/v2/lazyAgenda.ts
+++ b/packages/api/src/routes/v2/lazyAgenda.ts
@@ -1,0 +1,61 @@
+import { Router } from 'express';
+
+import { LazyAgendaController } from '../../controllers/v2/lazyAgenda';
+import { addUserLazyAgendaItemValidator } from '../../validators/lazyAgenda';
+import { authenticateToken } from '../../middlewares';
+
+export default (app: Router): void => {
+    const controller = new LazyAgendaController();
+    const route = Router();
+    app.use('/lazy-agenda', route);
+
+    /**
+     * @swagger
+     *
+     * /lazy-agenda:
+     *   get:
+     *     tags:
+     *     - "lazy-agenda"
+     *     summary: "Get all lazy agenda items for the user doing the request"
+     *     responses:
+     *       "200":
+     *         description: "Success"
+     *       "403":
+     *         description: "Invalid input"
+     */
+    route.get('/', controller.get);
+
+    /**
+     * @swagger
+     *
+     * /lazy-agenda:
+     *   post:
+     *     tags:
+     *     - "lazy-agenda"
+     *     summary: "Register a lazy agenda item"
+     *     requestBody:
+     *      required: true
+     *      content:
+     *        application/json:
+     *          schema:
+     *            type: object
+     *            properties:
+     *              type:
+     *                type: number
+     *                required: true
+     *              details:
+     *                type: object
+     *                required: false
+     *              frequency:
+     *                type: number
+     *                required: true
+     *     responses:
+     *       "200":
+     *         description: "Success"
+     *       "403":
+     *         description: "Invalid input"
+     *     security:
+     *     - BearerToken: []
+     */
+    route.post('/', authenticateToken, addUserLazyAgendaItemValidator, controller.add);
+};

--- a/packages/api/src/validators/lazyAgenda.ts
+++ b/packages/api/src/validators/lazyAgenda.ts
@@ -1,0 +1,20 @@
+import { Joi, celebrate } from 'celebrate';
+import { defaultSchema } from './defaultSchema';
+
+// I wish this comes true https://github.com/hapijs/joi/issues/2864#issuecomment-1322736004
+
+// This should match Joi validations
+type AddUserLazyAgendaItem = {
+    type: number;
+    details: object;
+    frequency: number;
+};
+const addUserLazyAgendaItemValidator = celebrate({
+    body: defaultSchema.object<AddUserLazyAgendaItem>({
+        type: Joi.number().required(),
+        details: Joi.object().optional(),
+        frequency: Joi.number().required()
+    })
+});
+
+export { addUserLazyAgendaItemValidator, AddUserLazyAgendaItem };

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -199,5 +199,12 @@ export default {
      */
     hotWallets: {
         huma: validatedEnv.HUMA_PRIVATE_KEY
+    },
+
+    /*
+     * Hot wallets
+     */
+    wallets: {
+        recurringDonationPrivateKey: validatedEnv.RECURRING_DONATION_PRIVATE_KEY
     }
 };

--- a/packages/core/src/config/validatenv.ts
+++ b/packages/core/src/config/validatenv.ts
@@ -120,7 +120,11 @@ function validateEnv() {
         CHAIN_JSON_RPC_URL_CELO: str({ default: 'https://alfajores-forno.celo-testnet.org' }),
         CHAIN_JSON_RPC_URL_POLYGON: str({ default: 'https://rpc-mumbai.maticvigil.com' }),
         // hot wallet variables
-        HUMA_PRIVATE_KEY: str({ default: '0785969a6f070bce78c7259252413d3e5099e990c042b27c561d6af59c8e506e' })
+        HUMA_PRIVATE_KEY: str({ default: '0785969a6f070bce78c7259252413d3e5099e990c042b27c561d6af59c8e506e' }),
+        // wallets
+        RECURRING_DONATION_PRIVATE_KEY: str({
+            default: 'xg8rprh6vzjja31xx2b6db5wwo2i5gmcc37c239wyp6jhyiefapev5738nvj77c4'
+        })
     });
 }
 

--- a/packages/core/src/database/db.ts
+++ b/packages/core/src/database/db.ts
@@ -6,6 +6,7 @@ import { AppAnonymousReportModel } from './models/app/anonymousReport';
 import { AppCICOProviderModel } from './models/cico/providers';
 import { AppClientCredentialModel } from './models/app/appClientCredential';
 import { AppExchangeRates } from './models/app/exchangeRates';
+import { AppLazyAgendaModel } from './models/app/appLazyAgenda';
 import { AppLogModel } from './models/app/appLog';
 import { AppNotificationModel } from './models/app/appNotification';
 import { AppProposalModel } from './models/app/appProposal';
@@ -74,6 +75,7 @@ export type DbModels = {
     ubiBeneficiarySurvey: ModelStatic<UbiBeneficiarySurveyModel>;
     appReferralCode: ModelStatic<AppReferralCodeModel>;
     appCICOProvider: ModelStatic<AppCICOProviderModel>;
+    appLazyAgenda: ModelStatic<AppLazyAgendaModel>;
     //
     community: ModelStatic<Community>;
     ubiCommunitySuspect: ModelStatic<UbiCommunitySuspectModel>;

--- a/packages/core/src/database/migrations/z20231002120856-create-app-lazy-agenda.js
+++ b/packages/core/src/database/migrations/z20231002120856-create-app-lazy-agenda.js
@@ -1,0 +1,37 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable('app_lazy_agenda', {
+            id: {
+                type: Sequelize.INTEGER,
+                autoIncrement: true,
+                primaryKey: true
+            },
+            userId: {
+                type: Sequelize.INTEGER,
+                allowNull: false
+            },
+            type: {
+                type: Sequelize.INTEGER,
+                allowNull: false
+            },
+            details: {
+                type: Sequelize.JSON,
+                allowNull: true
+            },
+            frequency: {
+                type: Sequelize.INTEGER,
+                allowNull: false
+            },
+            lastExecutedAt: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.NOW
+            }
+        });
+    },
+    async down(queryInterface, Sequelize) {
+        await queryInterface.dropTable('app_lazy_agenda');
+    }
+};

--- a/packages/core/src/database/models/app/appLazyAgenda.ts
+++ b/packages/core/src/database/models/app/appLazyAgenda.ts
@@ -1,0 +1,62 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+
+import { AppLazyAgenda, AppLazyAgendaCreation } from '../../../interfaces/app/appLazyAgenda';
+import { AppUserModel } from './appUser';
+import { DbModels } from '../../../database/db';
+
+export class AppLazyAgendaModel extends Model<AppLazyAgenda, AppLazyAgendaCreation> {
+    public id!: number;
+    public userId!: number;
+    public type!: number;
+    public details!: object;
+    public frequency!: number;
+    public lastExecutedAt!: Date;
+
+    public readonly user?: AppUserModel;
+}
+
+export function initializeAppLazyAgenda(sequelize: Sequelize): typeof AppLazyAgendaModel {
+    const { appUser } = sequelize.models as DbModels;
+    AppLazyAgendaModel.init(
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                autoIncrement: true,
+                primaryKey: true
+            },
+            userId: {
+                type: DataTypes.INTEGER,
+                references: {
+                    model: appUser,
+                    key: 'id'
+                },
+                onDelete: 'CASCADE',
+                allowNull: false
+            },
+            type: {
+                type: DataTypes.INTEGER,
+                allowNull: false
+            },
+            details: {
+                type: DataTypes.JSON,
+                allowNull: true
+            },
+            frequency: {
+                type: DataTypes.INTEGER,
+                allowNull: false
+            },
+            lastExecutedAt: {
+                type: DataTypes.DATE,
+                allowNull: false,
+                defaultValue: DataTypes.NOW
+            }
+        },
+        {
+            tableName: 'app_lazy_agenda',
+            modelName: 'appLazyAgenda',
+            sequelize,
+            timestamps: false
+        }
+    );
+    return AppLazyAgendaModel;
+}

--- a/packages/core/src/database/models/associations/user.ts
+++ b/packages/core/src/database/models/associations/user.ts
@@ -5,6 +5,7 @@ export function userAssociation(sequelize: Sequelize) {
     const {
         appUser,
         appLog,
+        appLazyAgenda,
         microCreditApplications,
         microCreditBorrowers,
         appReferralCode,
@@ -68,6 +69,12 @@ export function userAssociation(sequelize: Sequelize) {
     });
 
     microCreditLoanManager.belongsTo(appUser, {
+        foreignKey: 'userId',
+        targetKey: 'id',
+        as: 'user'
+    });
+
+    appLazyAgenda.belongsTo(appUser, {
         foreignKey: 'userId',
         targetKey: 'id',
         as: 'user'

--- a/packages/core/src/database/models/index.ts
+++ b/packages/core/src/database/models/index.ts
@@ -7,6 +7,7 @@ import { initializeAppAnonymousReport } from './app/anonymousReport';
 import { initializeAppCICOProvider } from './cico/providers';
 import { initializeAppClientCredential } from './app/appClientCredential';
 import { initializeAppExchangeRates } from './app/exchangeRates';
+import { initializeAppLazyAgenda } from './app/appLazyAgenda';
 import { initializeAppLog } from './app/appLog';
 import { initializeAppNotification } from './app/appNotification';
 import { initializeAppProposal } from './app/appProposal';
@@ -80,6 +81,7 @@ export default function initModels(sequelize: Sequelize): void {
     initializeAppUserValidationCode(sequelize);
     initializeAppReferralCode(sequelize);
     initializeAppCICOProvider(sequelize);
+    initializeAppLazyAgenda(sequelize);
 
     // ubi
     initializeCommunity(sequelize);

--- a/packages/core/src/interfaces/app/appLazyAgenda.ts
+++ b/packages/core/src/interfaces/app/appLazyAgenda.ts
@@ -1,0 +1,15 @@
+export interface AppLazyAgenda {
+    id: number;
+    userId: number;
+    type: number;
+    details: object;
+    frequency: number;
+    lastExecutedAt: Date;
+}
+
+export interface AppLazyAgendaCreation {
+    userId: number;
+    type: number;
+    details: object;
+    frequency: number;
+}

--- a/packages/core/src/services/app/index.ts
+++ b/packages/core/src/services/app/index.ts
@@ -1,5 +1,6 @@
 import CICOProviderService from './cicoProvider';
 import CashoutProviderService from './cashoutProvider';
 import ImMetadataService from './imMetadata';
+import LazyAgendaService from './lazyAgenda';
 
-export { ImMetadataService, CashoutProviderService, CICOProviderService };
+export { ImMetadataService, CashoutProviderService, LazyAgendaService, CICOProviderService };

--- a/packages/core/src/services/app/lazyAgenda.ts
+++ b/packages/core/src/services/app/lazyAgenda.ts
@@ -1,0 +1,16 @@
+import { AppLazyAgenda, AppLazyAgendaCreation } from '../../interfaces/app/appLazyAgenda';
+import { models } from '../../database';
+
+export default class LazyAgendaService {
+    public async get(userId: number): Promise<AppLazyAgenda[]> {
+        const lazyAgenda = await models.appLazyAgenda.findAll({
+            where: { userId }
+        });
+        return lazyAgenda.map(la => la.toJSON());
+    }
+
+    public async add(item: AppLazyAgendaCreation): Promise<AppLazyAgenda> {
+        const lazyAgenda = await models.appLazyAgenda.create(item);
+        return lazyAgenda.toJSON();
+    }
+}

--- a/packages/core/src/services/app/lazyAgenda.ts
+++ b/packages/core/src/services/app/lazyAgenda.ts
@@ -13,4 +13,10 @@ export default class LazyAgendaService {
         const lazyAgenda = await models.appLazyAgenda.create(item);
         return lazyAgenda.toJSON();
     }
+
+    public async delete(userId: number, id: number): Promise<void> {
+        await models.appLazyAgenda.destroy({
+            where: { id, userId }
+        });
+    }
 }

--- a/services/community-metrics/handler.ts
+++ b/services/community-metrics/handler.ts
@@ -9,6 +9,7 @@ import { updateCommunities } from './src/updateCommunities';
 import { updateExchangeRates } from './src/updateExchangeRates';
 import { validateBorrowersClaimHumaFunds, validateBorrowersRepayingHumaFunds } from './src/validateHumaBorrowers';
 import { verifyDeletedAccounts } from './src/user';
+import { verifyLazyAgenda } from './src/verifyLazyAgenda';
 
 global.btoa = (str: string) => Buffer.from(str, 'binary').toString('base64');
 global.atob = (str: string) => Buffer.from(str, 'base64').toString('binary');
@@ -34,5 +35,7 @@ export const calculate = async (event, context) => {
         await validateBorrowersRepayingHumaFunds();
     } else if (today.getHours() <= 8) {
         await updateCommunities();
+    } else if (today.getHours() <= 10) {
+        await verifyLazyAgenda();
     }
 };

--- a/services/community-metrics/package.json
+++ b/services/community-metrics/package.json
@@ -14,7 +14,8 @@
     "dependencies": {
         "@huma-finance/sdk": "0.0.44-beta.156",
         "@huma-finance/shared": "0.0.43-beta.112",
-        "@impactmarket/core": "1.0.0"
+        "@impactmarket/core": "1.0.0",
+        "ethers": "5.7.2"
     },
     "devDependencies": {
         "serverless": "3.35.2",

--- a/services/community-metrics/serverless.yml
+++ b/services/community-metrics/serverless.yml
@@ -33,6 +33,7 @@ functions:
       - schedule: cron(30 4 * * ? *)
       - schedule: cron(30 6 * * ? *)
       - schedule: cron(30 8 * * ? *)
+      - schedule: cron(30 10 * * ? *)
 
 plugins:
   - serverless-webpack

--- a/services/community-metrics/src/verifyLazyAgenda.ts
+++ b/services/community-metrics/src/verifyLazyAgenda.ts
@@ -1,0 +1,114 @@
+import { MailDataRequired } from '@sendgrid/mail';
+import { config, database, utils } from '@impactmarket/core';
+import { ethers } from 'ethers';
+import { sendEmail } from '@impactmarket/core/src/services/email';
+
+const { sequelize, models } = database;
+const { appLazyAgenda } = models;
+
+enum LazyAgendaType {
+    RECURRING_DONATION = 0
+}
+
+interface DonationMinerContract extends ethers.Contract {
+    donate(
+        token: string,
+        amount: ethers.BigNumber,
+        delegateAddress: string
+    ): Promise<ethers.providers.TransactionResponse>;
+}
+
+const donationMinerABI = [
+    {
+        inputs: [
+            {
+                internalType: 'contract IERC20Upgradeable',
+                name: '_token',
+                type: 'address'
+            },
+            {
+                internalType: 'uint256',
+                name: '_amount',
+                type: 'uint256'
+            },
+            {
+                internalType: 'address',
+                name: '_delegateAddress',
+                type: 'address'
+            }
+        ],
+        name: 'donate',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function'
+    }
+];
+
+export async function verifyLazyAgenda(): Promise<void> {
+    utils.Logger.info('Verifying user accounts to delete...');
+
+    // get all lazy agenda items that are due to be executed (lastExecutedAt + frequency < now)
+    // frequency can be any number of seconds
+    // include user address from app_user table
+    const lazyAgendaItems = await appLazyAgenda.findAll({
+        where: sequelize.literal(`(${new Date().getTime() / 1000} - frequency) <= "lastExecutedAt"`),
+        include: [{ attributes: ['address', 'email', 'firstName'], model: models.appUser, as: 'user' }]
+    });
+
+    const provider = new ethers.providers.JsonRpcProvider(config.jsonRpcUrl);
+
+    // for each lazy agenda item, execute the corresponding action
+    for (let i = 0; i < lazyAgendaItems.length; i++) {
+        const lazyAgendaItem = lazyAgendaItems[i];
+        const { type, details, user } = lazyAgendaItem;
+        switch (type) {
+            case LazyAgendaType.RECURRING_DONATION:
+                // execute the donation
+                const lazyAgendaTxExecutor = new ethers.Wallet(config.wallets.recurringDonationPrivateKey, provider);
+                const donationMinerContract = new ethers.Contract(
+                    config.contractAddresses.donationMiner,
+                    donationMinerABI,
+                    lazyAgendaTxExecutor
+                ) as DonationMinerContract;
+                try {
+                    const tx = await donationMinerContract.donate(
+                        config.cUSDContractAddress,
+                        ethers.utils.parseEther((details as { amount: number }).amount.toString()),
+                        user!.address
+                    );
+
+                    await tx.wait();
+
+                    // TODO: if allowance is getting low, notify user to increase it
+                } catch (e) {
+                    // email the user that the donation failed
+                    // build the email structure and send
+                    const dynamicTemplateData = {
+                        subject: 'Recurring donation',
+                        message: 'There was an error with your recurring donation!'
+                    };
+                    const personalizations = [
+                        {
+                            to: [{ email: user!.email }],
+                            dynamicTemplateData
+                        }
+                    ];
+                    const sendgridData: MailDataRequired = {
+                        from: {
+                            name: 'impactMarket',
+                            email: 'no-reply@impactmarket.com'
+                        },
+                        personalizations,
+                        templateId: 'd-2ed3ec93a94246478fcfd6650bb60375'
+                    };
+                    sendEmail(sendgridData);
+                }
+
+                // update the lastExecutedAt field
+                lazyAgendaItem.update({ lastExecutedAt: new Date() });
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/services/community-metrics/src/verifyLazyAgenda.ts
+++ b/services/community-metrics/src/verifyLazyAgenda.ts
@@ -11,7 +11,8 @@ enum LazyAgendaType {
 }
 
 interface DonationMinerContract extends ethers.Contract {
-    donate(
+    donateFrom(
+        from: string,
         token: string,
         amount: ethers.BigNumber,
         delegateAddress: string
@@ -22,6 +23,11 @@ const donationMinerABI = [
     {
         inputs: [
             {
+                internalType: 'address',
+                name: '_from',
+                type: 'address'
+            },
+            {
                 internalType: 'contract IERC20Upgradeable',
                 name: '_token',
                 type: 'address'
@@ -30,11 +36,6 @@ const donationMinerABI = [
                 internalType: 'uint256',
                 name: '_amount',
                 type: 'uint256'
-            },
-            {
-                internalType: 'address',
-                name: '_from',
-                type: 'address'
             },
             {
                 internalType: 'address',
@@ -94,9 +95,9 @@ export async function verifyLazyAgenda(): Promise<void> {
                 ) as DonationMinerContract;
                 try {
                     const txPopulate = await donationMinerContract.populateTransaction.donateFrom(
+                        user!.address,
                         config.cUSDContractAddress,
                         ethers.utils.parseEther((details as { amount: number }).amount.toString()),
-                        user!.address,
                         user!.address
                     );
                     const gasLimit = await lazyAgendaTxExecutor.estimateGas(txPopulate);


### PR DESCRIPTION
This PR fixes #833

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR create a new registry named `LazyAgenda`. The goal with this LazyAgenda is to create recurring tasks set by the user. It's only usage as of now is the recurring donations. Each item has an `frequency` (execution interval in seconds), a `type` and `details`.
In the case of recurring donations, `type` is "0", the `frequency` will be monthly (2592000) and the `details`, and object that contains the amount, eg `{ amount: 5 }`.

To use it, two new routes were created, `POST /lazy-agenda`, `GET /lazy-agenda` and `DELETE /lazy-agenda`.

The POST is used to create new entries. An example is provided on swagger. The GET should returns de complete list of items and the DELETE allows to delete an item.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
Manual