### PR TITLE
[bugfix] release db connection on learn-and-earn answer

### DIFF
--- a/packages/core/src/services/learnAndEarn/answer.ts
+++ b/packages/core/src/services/learnAndEarn/answer.ts
@@ -172,6 +172,7 @@ export async function answer(user: { userId: number; address: string }, answers:
             });
 
             // return wrong answers
+            sequelize.close();
             return {
                 success: false,
                 wrongAnswers,
@@ -272,6 +273,7 @@ export async function answer(user: { userId: number; address: string }, answers:
             }
 
             await t.commit();
+            sequelize.close();
             return {
                 success: true,
                 attempts,
@@ -282,6 +284,7 @@ export async function answer(user: { userId: number; address: string }, answers:
             };
         }
         await t.commit();
+        sequelize.close();
         return {
             success: true,
             attempts,


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

Each time the "answer" was called, a new db connection is created. But at the end, it was not released again to the connection pool, resulting in many connection open, stuck, blocking the connection pool. This PR fixes it.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
