### PR TITLE
[chore] hash subgraph query keys redis

### DIFF
--- a/packages/api/src/controllers/v2/user.ts
+++ b/packages/api/src/controllers/v2/user.ts
@@ -79,8 +79,9 @@ class UserController {
             });
             return;
         }
+        const clientId = parseInt(req.headers['client-id'] as string, 10);
         this.userService
-            .get(req.user.address)
+            .get(req.user.address, clientId)
             .then(user =>
                 standardResponse(res, 201, true, {
                     ...user,

--- a/packages/api/src/services/app/user/index.ts
+++ b/packages/api/src/services/app/user/index.ts
@@ -125,8 +125,23 @@ export default class UserService {
 
             [user, userRoles, userRules] = await Promise.all([
                 findAndUpdate(),
-                this._userRoles(userParams.address),
-                this._userRules(userParams.address)
+                clientId !== 2
+                    ? this._userRoles(userParams.address)
+                    : {
+                          roles: [],
+                          beneficiary: null,
+                          borrower: null,
+                          manager: null,
+                          councilMember: null,
+                          ambassador: null,
+                          loanManager: null
+                      },
+                clientId !== 2
+                    ? this._userRules(userParams.address)
+                    : {
+                          beneficiaryRules: false,
+                          managerRules: false
+                      }
             ]);
             notificationsCount = await models.appNotification.count({
                 where: {
@@ -149,13 +164,28 @@ export default class UserService {
         };
     }
 
-    public async get(address: string) {
+    public async get(address: string, clientId?: number) {
         const [user, userRoles, userRules] = await Promise.all([
             models.appUser.findOne({
                 where: { address }
             }),
-            this._userRoles(address),
-            this._userRules(address)
+            clientId !== 2
+                ? this._userRoles(address)
+                : {
+                      roles: [],
+                      beneficiary: null,
+                      borrower: null,
+                      manager: null,
+                      councilMember: null,
+                      ambassador: null,
+                      loanManager: null
+                  },
+            clientId !== 2
+                ? this._userRules(address)
+                : {
+                      beneficiaryRules: false,
+                      managerRules: false
+                  }
         ]);
 
         if (user === null) {

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "sourceMap": false,
-        "target": "es2017",
+        "target": "es2021",
         "module": "commonjs",
         "strict": true,
         "moduleResolution": "node",

--- a/packages/core/src/subgraph/queries/base.ts
+++ b/packages/core/src/subgraph/queries/base.ts
@@ -1,0 +1,3 @@
+import crypto from 'crypto';
+
+export const hashRedisKey = (key: string) => crypto.createHash('sha1').update(key.replaceAll(' ', '')).digest('base64');

--- a/packages/core/src/subgraph/queries/beneficiary.ts
+++ b/packages/core/src/subgraph/queries/beneficiary.ts
@@ -2,6 +2,7 @@ import { utils } from 'ethers';
 
 import { BeneficiarySubgraph } from '../interfaces/beneficiary';
 import { axiosMicrocreditSubgraph, axiosSubgraph } from '../config';
+import { hashRedisKey } from './base';
 import { intervalsInSeconds } from '../../types';
 import { redisClient } from '../../database';
 
@@ -36,7 +37,8 @@ export const getAllBeneficiaries = async (community: string): Promise<Beneficiar
                     }
                 }`
             };
-            const cacheResults = await redisClient.get(graphqlQuery.query);
+            const queryHash = hashRedisKey(graphqlQuery.query);
+            const cacheResults = await redisClient.get(queryHash);
 
             if (cacheResults) {
                 return JSON.parse(cacheResults);
@@ -63,7 +65,7 @@ export const getAllBeneficiaries = async (community: string): Promise<Beneficiar
 
             const beneficiaryEntities = response.data?.data.beneficiaryEntities;
 
-            redisClient.set(graphqlQuery.query, JSON.stringify(beneficiaryEntities), 'EX', intervalsInSeconds.oneHour);
+            redisClient.set(queryHash, JSON.stringify(beneficiaryEntities), 'EX', intervalsInSeconds.oneHour);
 
             result.push(...beneficiaryEntities);
 
@@ -220,7 +222,8 @@ export const getBeneficiaryCommunity = async (beneficiaryAddress: string): Promi
                 }
             }`
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -243,7 +246,7 @@ export const getBeneficiaryCommunity = async (beneficiaryAddress: string): Promi
 
         const beneficiaryEntity = response.data?.data.beneficiaryEntity;
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(beneficiaryEntity), 'EX', intervalsInSeconds.oneHour);
+        redisClient.set(queryHash, JSON.stringify(beneficiaryEntity), 'EX', intervalsInSeconds.oneHour);
 
         return utils.getAddress(beneficiaryEntity.community.id);
     } catch (error) {

--- a/packages/core/src/subgraph/queries/community.ts
+++ b/packages/core/src/subgraph/queries/community.ts
@@ -2,6 +2,7 @@ import { ethers } from 'ethers';
 import { getAddress } from '@ethersproject/address';
 
 import { axiosCouncilSubgraph, axiosSubgraph } from '../config';
+import { hashRedisKey } from './base';
 import { intervalsInSeconds } from '../../types';
 import { redisClient } from '../../database';
 import config from '../../config';
@@ -25,7 +26,8 @@ export const getCommunityProposal = async (): Promise<string[]> => {
                 }
             }`
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -46,7 +48,7 @@ export const getCommunityProposal = async (): Promise<string[]> => {
 
         const proposalEntities = response.data?.data.proposalEntities;
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(proposalEntities), 'EX', intervalsInSeconds.oneHour);
+        redisClient.set(queryHash, JSON.stringify(proposalEntities), 'EX', intervalsInSeconds.oneHour);
 
         return proposalEntities.map(proposal => proposal.calldatas[0]);
     } catch (error) {
@@ -79,7 +81,8 @@ export const getClaimed = async (
             }`,
             variables: {}
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -100,7 +103,7 @@ export const getClaimed = async (
         >('', graphqlQuery);
         const communityEntities = response.data?.data.communityEntities;
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(communityEntities), 'EX', intervalsInSeconds.halfHour);
+        redisClient.set(queryHash, JSON.stringify(communityEntities), 'EX', intervalsInSeconds.halfHour);
 
         return communityEntities;
     } catch (error) {
@@ -144,7 +147,8 @@ export const getCommunityState = async (
                 }
             }`
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -177,7 +181,7 @@ export const getCommunityState = async (
 
         const communityEntity = response.data?.data.communityEntity;
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(communityEntity), 'EX', intervalsInSeconds.halfHour);
+        redisClient.set(queryHash, JSON.stringify(communityEntity), 'EX', intervalsInSeconds.halfHour);
 
         return communityEntity;
     } catch (error) {
@@ -214,7 +218,8 @@ export const getCommunityUBIParams = async (
             }`,
             variables: {}
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -240,7 +245,7 @@ export const getCommunityUBIParams = async (
         >('', graphqlQuery);
         const communityEntity = response.data?.data.communityEntity;
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(communityEntity), 'EX', intervalsInSeconds.halfHour);
+        redisClient.set(queryHash, JSON.stringify(communityEntity), 'EX', intervalsInSeconds.halfHour);
 
         return communityEntity;
     } catch (error) {
@@ -261,7 +266,8 @@ export const communityEntities = async (where: string, fields: string) => {
             }`,
             variables: {}
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -270,7 +276,7 @@ export const communityEntities = async (where: string, fields: string) => {
         const response = await axiosSubgraph.post('', graphqlQuery);
         const communityEntities = response.data?.data.communityEntities;
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(communityEntities), 'EX', intervalsInSeconds.halfHour);
+        redisClient.set(queryHash, JSON.stringify(communityEntities), 'EX', intervalsInSeconds.halfHour);
 
         return communityEntities;
     } catch (error) {
@@ -293,7 +299,8 @@ export const getBiggestCommunities = async (limit: number, offset: number, order
             }
         }`
     };
-    const cacheResults = await redisClient.get(graphqlQuery.query);
+    const queryHash = hashRedisKey(graphqlQuery.query);
+    const cacheResults = await redisClient.get(queryHash);
 
     if (cacheResults) {
         return JSON.parse(cacheResults);
@@ -314,7 +321,7 @@ export const getBiggestCommunities = async (limit: number, offset: number, order
     >('', graphqlQuery);
     const communities = response.data?.data.communityEntities;
 
-    redisClient.set(graphqlQuery.query, JSON.stringify(communities), 'EX', intervalsInSeconds.halfHour);
+    redisClient.set(queryHash, JSON.stringify(communities), 'EX', intervalsInSeconds.halfHour);
 
     return communities;
 };
@@ -336,7 +343,8 @@ export const getCommunityAmbassador = async (community: string) => {
         }`,
         variables: {}
     };
-    const cacheResults = await redisClient.get(graphqlQuery.query);
+    const queryHash = hashRedisKey(graphqlQuery.query);
+    const cacheResults = await redisClient.get(queryHash);
 
     if (cacheResults) {
         return JSON.parse(cacheResults);
@@ -345,7 +353,7 @@ export const getCommunityAmbassador = async (community: string) => {
     const response = await axiosCouncilSubgraph.post('', graphqlQuery);
     const ambassador = response.data?.data.ambassadorEntities[0];
 
-    redisClient.set(graphqlQuery.query, JSON.stringify(ambassador), 'EX', intervalsInSeconds.sixHours);
+    redisClient.set(queryHash, JSON.stringify(ambassador), 'EX', intervalsInSeconds.sixHours);
 
     return ambassador;
 };
@@ -367,7 +375,8 @@ export const getAmbassadorByAddress = async (ambassadorAddress: string) => {
             }`,
             variables: {}
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -388,7 +397,7 @@ export const getAmbassadorByAddress = async (ambassadorAddress: string) => {
         >('', graphqlQuery);
         const ambassadorEntities = response.data?.data.ambassadorEntities[0];
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(ambassadorEntities), 'EX', intervalsInSeconds.sixHours);
+        redisClient.set(queryHash, JSON.stringify(ambassadorEntities), 'EX', intervalsInSeconds.sixHours);
 
         return ambassadorEntities;
     } catch (error) {
@@ -423,7 +432,8 @@ export const getCommunityStateByAddresses = async (
             }`,
             variables: {}
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -445,7 +455,7 @@ export const getCommunityStateByAddresses = async (
         >('', graphqlQuery);
         const communityEntities = response.data?.data.communityEntities;
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(communityEntities), 'EX', intervalsInSeconds.oneHour);
+        redisClient.set(queryHash, JSON.stringify(communityEntities), 'EX', intervalsInSeconds.oneHour);
 
         return communityEntities;
     } catch (error) {

--- a/packages/core/src/subgraph/queries/microcredit.ts
+++ b/packages/core/src/subgraph/queries/microcredit.ts
@@ -1,4 +1,5 @@
 import { axiosMicrocreditSubgraph } from '../config';
+import { hashRedisKey } from './base';
 import { intervalsInSeconds } from '../../types';
 import { redisClient } from '../../database';
 
@@ -151,8 +152,8 @@ export const getMicroCreditStatsLastDays = async (
                 }
             }`
         };
-
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -211,7 +212,7 @@ export const getMicroCreditStatsLastDays = async (
             interest
         };
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(stats), 'EX', intervalsInSeconds.twoMins);
+        redisClient.set(queryHash, JSON.stringify(stats), 'EX', intervalsInSeconds.twoMins);
 
         return stats;
     } catch (error) {
@@ -274,8 +275,8 @@ export const getBorrowerRepayments = async (query: {
             }
         }`
     };
-
-    const cacheResults = await redisClient.get(graphqlQuery.query);
+    const queryHash = hashRedisKey(graphqlQuery.query);
+    const cacheResults = await redisClient.get(queryHash);
 
     if (cacheResults) {
         return JSON.parse(cacheResults);
@@ -307,7 +308,7 @@ export const getBorrowerRepayments = async (query: {
             timestamp: repayment.timestamp
         }))
     };
-    redisClient.set(graphqlQuery.query, JSON.stringify(repaymentsAndCount), 'EX', intervalsInSeconds.halfHour);
+    redisClient.set(queryHash, JSON.stringify(repaymentsAndCount), 'EX', intervalsInSeconds.halfHour);
 
     return repaymentsAndCount;
 };
@@ -334,8 +335,8 @@ export const countGetBorrowers = async (query: SubgraphGetBorrowersQuery): Promi
             }
         }`
     };
-
-    const cacheResults = await redisClient.get(graphqlQuery.query);
+    const queryHash = hashRedisKey(graphqlQuery.query);
+    const cacheResults = await redisClient.get(queryHash);
 
     if (cacheResults) {
         return JSON.parse(cacheResults);
@@ -355,7 +356,7 @@ export const countGetBorrowers = async (query: SubgraphGetBorrowersQuery): Promi
     >('', graphqlQuery);
 
     const borrowers = response.data?.data.borrowers.length;
-    redisClient.set(graphqlQuery.query, JSON.stringify(borrowers), 'EX', intervalsInSeconds.twoMins);
+    redisClient.set(queryHash, JSON.stringify(borrowers), 'EX', intervalsInSeconds.twoMins);
 
     return borrowers;
 };
@@ -445,8 +446,8 @@ export const getBorrowers = async (
             }
         }`
     };
-
-    const cacheResults = await redisClient.get(graphqlQuery.query);
+    const queryHash = hashRedisKey(graphqlQuery.query);
+    const cacheResults = await redisClient.get(queryHash);
 
     if (cacheResults) {
         return JSON.parse(cacheResults);
@@ -488,7 +489,7 @@ export const getBorrowers = async (
         },
         id: borrower.id
     }));
-    redisClient.set(graphqlQuery.query, JSON.stringify({ borrowers }), 'EX', intervalsInSeconds.twoMins);
+    redisClient.set(queryHash, JSON.stringify({ borrowers }), 'EX', intervalsInSeconds.twoMins);
 
     return { borrowers };
 };
@@ -506,8 +507,8 @@ export const getBorrowerLoansCount = async (borrower: string): Promise<number> =
             }
         }`
     };
-
-    const cacheResults = await redisClient.get(graphqlQuery.query);
+    const queryHash = hashRedisKey(graphqlQuery.query);
+    const cacheResults = await redisClient.get(queryHash);
 
     if (cacheResults) {
         return JSON.parse(cacheResults);
@@ -527,7 +528,7 @@ export const getBorrowerLoansCount = async (borrower: string): Promise<number> =
     >('', graphqlQuery);
 
     const loans = response.data?.data.borrower?.loans.length ?? 0;
-    redisClient.set(graphqlQuery.query, JSON.stringify(loans), 'EX', intervalsInSeconds.twoMins);
+    redisClient.set(queryHash, JSON.stringify(loans), 'EX', intervalsInSeconds.twoMins);
 
     return loans;
 };
@@ -541,8 +542,8 @@ export const getLoanRepayments = async (userAddress: string, loanId: number): Pr
             }
         }`
     };
-
-    const cacheResults = await redisClient.get(graphqlQuery.query);
+    const queryHash = hashRedisKey(graphqlQuery.query);
+    const cacheResults = await redisClient.get(queryHash);
 
     if (cacheResults) {
         return JSON.parse(cacheResults);
@@ -562,7 +563,7 @@ export const getLoanRepayments = async (userAddress: string, loanId: number): Pr
     >('', graphqlQuery);
 
     const loanRepayments = response.data?.data.loan.repayments;
-    redisClient.set(graphqlQuery.query, JSON.stringify(loanRepayments), 'EX', intervalsInSeconds.twoMins);
+    redisClient.set(queryHash, JSON.stringify(loanRepayments), 'EX', intervalsInSeconds.twoMins);
 
     return loanRepayments;
 };
@@ -583,8 +584,8 @@ export const getLoanManager = async (
             }
         }`
     };
-
-    const cacheResults = await redisClient.get(graphqlQuery.query);
+    const queryHash = hashRedisKey(graphqlQuery.query);
+    const cacheResults = await redisClient.get(queryHash);
 
     if (cacheResults) {
         return JSON.parse(cacheResults);
@@ -606,7 +607,7 @@ export const getLoanManager = async (
 
     const loanManager = response.data?.data.loanManager;
 
-    redisClient.set(graphqlQuery.query, JSON.stringify(loanManager), 'EX', intervalsInSeconds.twoMins);
+    redisClient.set(queryHash, JSON.stringify(loanManager), 'EX', intervalsInSeconds.twoMins);
 
     return loanManager;
 };

--- a/packages/core/src/subgraph/queries/referrals.ts
+++ b/packages/core/src/subgraph/queries/referrals.ts
@@ -1,4 +1,5 @@
 import { axiosSubgraph } from '../config';
+import { hashRedisKey } from './base';
 import { intervalsInSeconds } from '../../types';
 import { redisClient } from '../../database';
 
@@ -25,7 +26,8 @@ export const getReferralCampaigns = async (): Promise<
                 }
             }`
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -47,7 +49,7 @@ export const getReferralCampaigns = async (): Promise<
         >('', graphqlQuery);
 
         redisClient.set(
-            graphqlQuery.query,
+            queryHash,
             JSON.stringify(response.data?.data.referralCampaigns),
             'EX',
             intervalsInSeconds.oneHour

--- a/packages/core/src/subgraph/queries/ubi.ts
+++ b/packages/core/src/subgraph/queries/ubi.ts
@@ -1,4 +1,5 @@
 import { axiosSubgraph } from '../config';
+import { hashRedisKey } from './base';
 import { intervalsInSeconds } from '../../types';
 import { redisClient } from '../../database';
 
@@ -43,7 +44,8 @@ export const getUbiDailyEntity = async (
                 }
             }`
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -73,7 +75,7 @@ export const getUbiDailyEntity = async (
 
         const ubidailyEntities = response.data?.data.ubidailyEntities;
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(ubidailyEntities), 'EX', intervalsInSeconds.oneHour);
+        redisClient.set(queryHash, JSON.stringify(ubidailyEntities), 'EX', intervalsInSeconds.oneHour);
 
         return ubidailyEntities;
     } catch (error) {

--- a/packages/core/src/subgraph/queries/user.ts
+++ b/packages/core/src/subgraph/queries/user.ts
@@ -1,4 +1,5 @@
 import { axiosCouncilSubgraph, axiosMicrocreditSubgraph, axiosSubgraph } from '../config';
+import { hashRedisKey } from './base';
 import { intervalsInSeconds } from '../../types';
 import { redisClient } from '../../database';
 
@@ -99,7 +100,6 @@ export const getUserRoles = async (address: string): Promise<UserRoles> => {
                 }
             }`
         };
-
         const cachedRoles = await redisClient.get(`account-roles-${address.toLowerCase()}`);
 
         let responseDAO: DAOResponse | null = null;
@@ -243,7 +243,8 @@ export const getUserActivity = async (
                 }
             }`
         };
-        const cacheResults = await redisClient.get(graphqlQuery.query);
+        const queryHash = hashRedisKey(graphqlQuery.query);
+        const cacheResults = await redisClient.get(queryHash);
 
         if (cacheResults) {
             return JSON.parse(cacheResults);
@@ -271,7 +272,7 @@ export const getUserActivity = async (
 
         const userActivityEntities = response.data?.data.userActivityEntities;
 
-        redisClient.set(graphqlQuery.query, JSON.stringify(userActivityEntities), 'EX', intervalsInSeconds.halfHour);
+        redisClient.set(queryHash, JSON.stringify(userActivityEntities), 'EX', intervalsInSeconds.halfHour);
 
         return userActivityEntities;
     } catch (error) {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "baseUrl": "./src",
         "sourceMap": false,
-        "target": "es2017",
+        "target": "es2021",
         "module": "commonjs",
         "strict": true,
         "moduleResolution": "node",

--- a/services/microcredit/tsconfig.json
+++ b/services/microcredit/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "baseUrl": "./",
         "sourceMap": true,
-        "target": "es6",
+        "target": "es2021",
         "module": "commonjs",
         "strict": true,
         "moduleResolution": "node",


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR fixes some very long redis keys to short ones. This mostly happened with subgraph queries.
Example
```javascript
// before
const x = 'query proposalEntities {                proposalEntities(                    where: {                        status: 0                        endBlock_gt: 19743995                        signatures_contains:["addCommunity(address[],address,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)"]                    }                ) {                    calldatas                }            }'
// after
const y = '6xwzvdQXx9Ift1kSF7GVI9Mop+I='
```

Because we are using this hash to create a unique id and not for cryptography purposes, what matters is the fastest.
So this uses the fastest hash in nodejs, according to [this article](https://medium.com/@chris_72272/what-is-the-fastest-node-js-hashing-algorithm-c15c1a0e164e).

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
