### PR TITLE
[hotfix] remove global claim cache

### DIFF
--- a/packages/api/src/routes/v2/claimLocation.ts
+++ b/packages/api/src/routes/v2/claimLocation.ts
@@ -25,7 +25,8 @@ export default (app: Router): void => {
      *       "403":
      *         description: "Invalid input"
      */
-    route.get('/', cache(cacheIntervals.oneDay), controller.getAll);
+    route.get('/', controller.getAll);
+    // route.get('/', cache(cacheIntervals.oneDay), controller.getAll);
 
     /**
      * @swagger

--- a/packages/api/src/routes/v2/claimLocation.ts
+++ b/packages/api/src/routes/v2/claimLocation.ts
@@ -2,8 +2,6 @@ import { Router } from 'express';
 
 import { ClaimLocationController } from '../../controllers/v2/claimLocation';
 import { authenticateToken } from '../../middlewares';
-import { cache } from '../../middlewares/cache-redis';
-import { cacheIntervals } from '../../utils/api';
 import claimLocationValidators from '../../validators/claimLocation';
 
 export default (app: Router): void => {


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR removes cache on global claim location endpoint, which, upon issues with redis, was blowing up the Dyno's RAM. Similar to https://github.com/impactMarket/backend/issues/887

![image](https://github.com/impactMarket/backend/assets/19441097/f68794e3-d409-4673-bd9b-0bfa8b6d4e31)

```
17-09-2023 16:26:07.035[heroku-logs][INFO][router][heroku]at=info method=GET path="/api/v2/claims-location" host=impactmarket-api-production.herokuapp.com request_id=86ee3203-a031-41c4-bc49-f1fc630c1133 fwd="197.210.53.178" dyno=web.1 connect=1ms service=126ms status=200 bytes=318450 protocol=https
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] }
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] name: 'set',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku]ReplyError: ERR syntax error
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] triggerUncaughtException(err, true /* fromPromise */);
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku]Node.js v18.17.1
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] ... 4424 more items
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '__express__/api/v2/claims-location',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] at parseError (/app/node_modules/redis-parser/lib/parser.js:179:12)
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] ^
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] command: {
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku]node:internal/process/promises:288
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku] '[object Object]',
+17-09-2023 16:26:07.693[heroku-logs][INFO][web.1][heroku]}
+17-09-2023 16:26:09.685[heroku-logs][INFO][web.1][heroku]error Command failed with exit code 1.
+17-09-2023 16:26:09.688[heroku-logs][INFO][web.1][heroku]info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+17-09-2023 16:26:10.000[heroku-logs][INFO][][heroku]58 <190>1 2023-09-17T15:26:07.693437+00:00 host app web.1 -
+17-09-2023 16:26:10.000[heroku-logs][INFO][][heroku]58 <190>1 2023-09-17T15:26:07.693464+00:00 host app web.1 -
+17-09-2023 16:26:10.141[heroku-logs][INFO][web.1][heroku]Process exited with status 1
+17-09-2023 16:26:10.173[heroku-logs][INFO][web.1][heroku]State changed from up to crashed
```

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
