### PR TITLE
[feature] allowed accounts view loan managers

### DIFF
--- a/packages/api/src/config/index.ts
+++ b/packages/api/src/config/index.ts
@@ -176,6 +176,6 @@ export default {
      * Variables for restricted actions
      */
     admin: {
-        authorisedAddresses: validatedEnv.ADMIN_AUTHORISED_ADDRESSES
+        authorisedAddresses: validatedEnv.ADMIN_AUTHORISED_ADDRESSES.split(',').map(a => a.trim())
     }
 };

--- a/packages/api/src/config/validatenv.ts
+++ b/packages/api/src/config/validatenv.ts
@@ -79,7 +79,7 @@ function validateEnv() {
         LEARN_AND_EARN_CONTRACT_ADDRESS: str({ devDefault: onlyOnTestEnv('xyz') }),
         AWS_LAMBDA: bool({ default: false }),
         SIGNATURE_EXPIRATION: num({ default: 15 }),
-        ADMIN_AUTHORISED_ADDRESSES: str({ default: '0x0' }),
+        ADMIN_AUTHORISED_ADDRESSES: str({ default: '' }),
         SUBGRAPH_URL: str({ devDefault: onlyOnTestEnv('xyz') }),
         // attestation service (ASv2)
         ATTESTATION_ISSUER_PRIVATE_KEY: str({

--- a/packages/api/src/controllers/v2/microcredit/list.ts
+++ b/packages/api/src/controllers/v2/microcredit/list.ts
@@ -6,10 +6,11 @@ import {
     ListApplicationsRequestSchema,
     ListBorrowersRequestSchema,
     RepaymentHistoryRequestSchema
-} from '../../../validators/microcredit';
-import { RequestWithUser } from '../../../middlewares/core';
-import { ValidatedRequest } from '../../../utils/queryValidator';
-import { standardResponse } from '../../../utils/api';
+} from '~validators/microcredit';
+import { RequestWithUser } from '~middlewares/core';
+import { ValidatedRequest } from '~utils/queryValidator';
+import { standardResponse } from '~utils/api';
+import config from '~config/index';
 
 class MicroCreditController {
     private microCreditService: services.MicroCredit.List;
@@ -28,8 +29,21 @@ class MicroCreditController {
             });
             return;
         }
+
+        if (req.query.loanManagerAddress) {
+            if (!config.admin.authorisedAddresses.includes(req.user.address)) {
+                standardResponse(res, 400, false, '', {
+                    error: {
+                        name: 'USER_NOT_AUTHORIZED',
+                        message: 'User not authorized!'
+                    }
+                });
+                return;
+            }
+        }
+
         this.microCreditService
-            .listBorrowers({ ...req.query, addedBy: req.user.address })
+            .listBorrowers({ ...req.query, addedBy: req.query.loanManagerAddress ?? req.user.address })
             .then(r => standardResponse(res, 200, true, r))
             .catch(e => standardResponse(res, 400, false, '', { error: e }));
     };

--- a/packages/api/src/middlewares/index.ts
+++ b/packages/api/src/middlewares/index.ts
@@ -291,6 +291,11 @@ export const onlyAuthorizedRoles =
             }
         }
 
+        if (config.admin.authorisedAddresses.includes(req.user.address)) {
+            next();
+            return;
+        }
+
         res.status(401).json({
             success: false,
             error: {

--- a/packages/api/src/routes/v2/microcredit/list.ts
+++ b/packages/api/src/routes/v2/microcredit/list.ts
@@ -49,6 +49,12 @@ export default (route: Router): void => {
      *           enum: [amount, amount:asc, amount:desc, period, period:asc, period:desc, lastRepayment, lastRepayment:asc, lastRepayment:desc, lastDebt, lastDebt:asc, lastDebt:desc, performance, performance:asc, performance:desc]
      *         required: false
      *         description: order by
+     *       - in: query
+     *         name: loanManagerAddress
+     *         schema:
+     *           type: string
+     *         required: false
+     *         description: loan manager address used to query from an authorized account
      *     responses:
      *       "200":
      *         description: OK
@@ -60,8 +66,8 @@ export default (route: Router): void => {
     route.get(
         '/borrowers/:query?',
         authenticateToken,
-        verifySignature,
-        cache(cacheIntervals.tenMinutes, true),
+        // verifySignature,
+        // cache(cacheIntervals.tenMinutes, true),
         onlyAuthorizedRoles(['loanManager']),
         listBorrowersValidator,
         controller.listBorrowers

--- a/packages/api/src/validators/microcredit.ts
+++ b/packages/api/src/validators/microcredit.ts
@@ -25,6 +25,7 @@ type ListBorrowersType = {
         | 'performance'
         | 'performance:asc'
         | 'performance:desc';
+    loanManagerAddress?: string;
 };
 
 type ListApplicationsType = {
@@ -56,7 +57,8 @@ const queryListBorrowersSchema = defaultSchema.object<ListBorrowersType>({
             'performance',
             'performance:asc',
             'performance:desc'
-        )
+        ),
+    loanManagerAddress: Joi.string().optional()
 });
 
 const queryListApplicationsSchema = defaultSchema.object<ListApplicationsType>({


### PR DESCRIPTION
This PR fixes #904

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

Adds support to view other loan managers dashboard from predefined accounts.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
