### PR TITLE
loan managers by country and countries

### DIFF
--- a/packages/api/src/controllers/v2/microcredit/list.ts
+++ b/packages/api/src/controllers/v2/microcredit/list.ts
@@ -115,7 +115,14 @@ class MicroCreditController {
         const country = req.params.country as string;
 
         this.microCreditService
-            .getLoanManagersByCountry(country)
+            .getLoanManagersByCountry(country.toUpperCase())
+            .then(r => standardResponse(res, 200, true, r))
+            .catch(e => standardResponse(res, 400, false, '', { error: e }));
+    };
+
+    getMicroCreditCountries = (_req: RequestWithUser, res: Response) => {
+        this.microCreditService
+            .getMicroCreditCountries()
             .then(r => standardResponse(res, 200, true, r))
             .catch(e => standardResponse(res, 400, false, '', { error: e }));
     };

--- a/packages/api/src/routes/v2/microcredit/list.ts
+++ b/packages/api/src/routes/v2/microcredit/list.ts
@@ -280,10 +280,24 @@ export default (route: Router): void => {
      *         schema:
      *           type: string
      *         required: true
-     *         description: country tag (eg.  NG, KE, GH, etc.)
+     *         description: country tag (eg.  NG, VE, GH, etc.)
      *     responses:
      *       "200":
      *         description: OK
      */
-    route.get('/managers/:country', cache(cacheIntervals.halfHour), controller.getLoanManagersByCountry);
+    route.get('/managers/:country', controller.getLoanManagersByCountry);
+
+    /**
+     * @swagger
+     *
+     * /microcredit:
+     *   get:
+     *     tags:
+     *       - "microcredit"
+     *     summary: "Get countries where microcredit is available"
+     *     responses:
+     *       "200":
+     *         description: OK
+     */
+    route.get('/', controller.getMicroCreditCountries);
 };

--- a/packages/core/src/database/db.ts
+++ b/packages/core/src/database/db.ts
@@ -37,6 +37,7 @@ import { MicroCreditApplicationModel } from './models/microCredit/applications';
 import { MicroCreditBorrowersHumaModel } from './models/microCredit/borrowersHuma';
 import { MicroCreditBorrowersModel } from './models/microCredit/borrowers';
 import { MicroCreditDocsModel } from './models/microCredit/docs';
+import { MicroCreditLoanManagerModel } from './models/microCredit/loanManagers';
 import { MicroCreditNoteModel } from './models/microCredit/note';
 import { StoryCommentModel } from './models/story/storyComment';
 import { StoryCommunityModel } from './models/story/storyCommunity';
@@ -123,6 +124,7 @@ export type DbModels = {
     microCreditBorrowersHuma: ModelStatic<MicroCreditBorrowersHumaModel>;
     microCreditNote: ModelStatic<MicroCreditNoteModel>;
     subgraphMicroCreditBorrowers: ModelStatic<SubgraphMicroCreditBorrowersModel>;
+    microCreditLoanManager: ModelStatic<MicroCreditLoanManagerModel>;
     //
     exchangeRegistry: ModelStatic<ExchangeRegistryModel>;
 };

--- a/packages/core/src/database/migrations/z20230922170956-create-microcredit-loan-manager.js
+++ b/packages/core/src/database/migrations/z20230922170956-create-microcredit-loan-manager.js
@@ -1,0 +1,24 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable('microcredit_loan_manager', {
+            id: {
+                type: Sequelize.INTEGER,
+                autoIncrement: true,
+                primaryKey: true
+            },
+            userId: {
+                type: Sequelize.INTEGER,
+                allowNull: false
+            },
+            country: {
+                type: Sequelize.STRING,
+                allowNull: false
+            }
+        });
+    },
+    async down(queryInterface, Sequelize) {
+        await queryInterface.dropTable('microcredit_loan_manager');
+    }
+};

--- a/packages/core/src/database/migrations/z20230922170957-update-microcredit-loan-manager.js
+++ b/packages/core/src/database/migrations/z20230922170957-update-microcredit-loan-manager.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+
+        if (process.env.API_ENVIRONMENT === 'staging') {
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5857, 'BR')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5855, 'BR')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5898, 'BR')`);
+    
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5855, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5801, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5896, 'UG')`);
+    
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5853, 'NG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5700, 'NG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5893, 'NG')`);
+            
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5853, 'GH')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5857, 'GH')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5801, 'GH')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5891, 'GH')`);
+    
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (5853, 'VE')`);
+        } else if (process.env.API_ENVIRONMENT === 'production') {
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (106251, 'BR')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (12928, 'BR')`);
+    
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (106251, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (30880, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (99878, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (101542, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (52493, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (47511, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (32522, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (27371, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (107433, 'UG')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (56673, 'UG')`);
+    
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (106251, 'GH')`);
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (108792, 'GH')`);
+    
+            await queryInterface.sequelize.query(`insert into microcredit_loan_manager ("userId", country) values (88662, 'VE')`);
+        }
+
+    },
+    down: queryInterface => {}
+};

--- a/packages/core/src/database/models/associations/user.ts
+++ b/packages/core/src/database/models/associations/user.ts
@@ -9,7 +9,8 @@ export function userAssociation(sequelize: Sequelize) {
         microCreditBorrowers,
         appReferralCode,
         microCreditNote,
-        subgraphMicroCreditBorrowers
+        subgraphMicroCreditBorrowers,
+        microCreditLoanManager
     } = sequelize.models as DbModels;
 
     appLog.belongsTo(appUser, {
@@ -64,5 +65,11 @@ export function userAssociation(sequelize: Sequelize) {
         foreignKey: 'userId',
         sourceKey: 'userId',
         as: 'loan'
+    });
+
+    microCreditLoanManager.belongsTo(appUser, {
+        foreignKey: 'userId',
+        targetKey: 'id',
+        as: 'user'
     });
 }

--- a/packages/core/src/database/models/index.ts
+++ b/packages/core/src/database/models/index.ts
@@ -37,6 +37,7 @@ import { initializeMicroCreditApplication } from './microCredit/applications';
 import { initializeMicroCreditBorrowers } from './microCredit/borrowers';
 import { initializeMicroCreditBorrowersHuma } from './microCredit/borrowersHuma';
 import { initializeMicroCreditDocs } from './microCredit/docs';
+import { initializeMicroCreditLoanManager } from './microCredit/loanManagers';
 import { initializeMicroCreditNote } from './microCredit/note';
 import { initializeStoryComment } from './story/storyComment';
 import { initializeStoryCommunity } from './story/storyCommunity';
@@ -137,6 +138,7 @@ export default function initModels(sequelize: Sequelize): void {
     initializeMicroCreditBorrowersHuma(sequelize);
     initializeMicroCreditNote(sequelize);
     initializeSubgraphMicroCreditBorrowers(sequelize);
+    initializeMicroCreditLoanManager(sequelize);
 
     // Exchange
     initializeExchangeRegistry(sequelize);

--- a/packages/core/src/database/models/microCredit/loanManagers.ts
+++ b/packages/core/src/database/models/microCredit/loanManagers.ts
@@ -1,0 +1,46 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+
+import { AppUserModel } from '../app/appUser';
+import { DbModels } from '../../../database/db';
+import { MicroCreditLoanManager, MicroCreditLoanManagerAttributes } from '../../../interfaces/microCredit/loanManager';
+
+export class MicroCreditLoanManagerModel extends Model<MicroCreditLoanManager, MicroCreditLoanManagerAttributes> {
+    public id!: number;
+    public userId!: number;
+    public country!: string;
+
+    public readonly user?: AppUserModel;
+}
+
+export function initializeMicroCreditLoanManager(sequelize: Sequelize): typeof MicroCreditLoanManagerModel {
+    const { appUser } = sequelize.models as DbModels;
+    MicroCreditLoanManagerModel.init(
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                autoIncrement: true,
+                primaryKey: true
+            },
+            userId: {
+                type: DataTypes.INTEGER,
+                references: {
+                    model: appUser,
+                    key: 'id'
+                },
+                onDelete: 'CASCADE',
+                allowNull: false
+            },
+            country: {
+                type: DataTypes.STRING,
+                allowNull: false
+            }
+        },
+        {
+            tableName: 'microcredit_loan_manager',
+            modelName: 'microCreditLoanManager',
+            sequelize,
+            timestamps: false
+        }
+    );
+    return MicroCreditLoanManagerModel;
+}

--- a/packages/core/src/interfaces/microCredit/loanManager.ts
+++ b/packages/core/src/interfaces/microCredit/loanManager.ts
@@ -1,0 +1,10 @@
+export interface MicroCreditLoanManager {
+    id: number;
+    userId: number;
+    country: string;
+}
+
+export interface MicroCreditLoanManagerAttributes {
+    userId: number;
+    country: string;
+}

--- a/packages/core/src/services/microcredit/list.ts
+++ b/packages/core/src/services/microcredit/list.ts
@@ -1,6 +1,6 @@
 import { MicroCreditApplication, MicroCreditApplicationStatus } from '../../interfaces/microCredit/applications';
 import { MicroCreditBorrowers } from '../../interfaces/microCredit/borrowers';
-import { Op, Order, WhereOptions, literal } from 'sequelize';
+import { Op, Order, WhereOptions, col, fn, literal } from 'sequelize';
 import { config } from '../../..';
 import { getAddress } from '@ethersproject/address';
 import {
@@ -658,54 +658,28 @@ export default class MicroCreditList {
     };
 
     public getLoanManagersByCountry = async (country: string) => {
-        let loanManagers: number[] = [];
-
-        // TODO: this is hardcoded for now, but we should have a better way to do this
-        if (config.jsonRpcUrl.indexOf('alfajores') !== -1) {
-            switch (country.toLowerCase()) {
-                case 'br':
-                    loanManagers = [5857, 5855, 5898];
-                    break;
-                case 'ug':
-                    loanManagers = [5855, 5801, 5896];
-                    break;
-                case 'ng':
-                    loanManagers = [5853, 5700, 5893];
-                    break;
-                // case 've':
-                default:
-                    loanManagers = [5853, 5857, 5801, 5891];
-                    break;
-            }
-        } else {
-            switch (country.toLowerCase()) {
-                case 'br':
-                    loanManagers = [106251, 12928];
-                    break;
-                case 'ug':
-                    loanManagers = [106251, 30880, 99878, 101542, 52493, 47511, 32522, 27371, 107433, 56673];
-                    break;
-                case 'gh':
-                    loanManagers = [106251, 108792];
-                    break;
-                case 've':
-                    loanManagers = [88662];
-                    break;
-                default:
-                    loanManagers = [106251];
-                    break;
-            }
-        }
-
-        const users = await models.appUser.findAll({
-            attributes: ['id', 'address', 'firstName', 'lastName', 'avatarMediaPath'],
-            where: {
-                id: {
-                    [Op.in]: loanManagers
+        const loanManagers = await models.microCreditLoanManager.findAll({
+            attributes: [],
+            include: [
+                {
+                    model: models.appUser,
+                    attributes: ['id', 'address', 'firstName', 'lastName', 'avatarMediaPath'],
+                    as: 'user'
                 }
+            ],
+            where: {
+                country
             }
         });
 
-        return users.map(u => u.toJSON());
+        return loanManagers.map(u => u.user!.toJSON());
+    };
+
+    public getMicroCreditCountries = async () => {
+        const countries = await models.microCreditLoanManager.findAll({
+            attributes: [[fn('DISTINCT', col('country')) ,'country']]
+        });
+
+        return countries.map(c => c.country);
     };
 }


### PR DESCRIPTION
This PR fixes #901

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

Does not change the request or response in regards of getting loan managers by country. What changes is that, now, this data come from a tables, rather than being hardcoded.

Adds a new `GET /microcredit` endpoint which returns an array with countries where there are loan managers.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
