### PR TITLE
[bugfix] set lastRepaymentAmount 0 when is null

### DIFF
--- a/services/microcredit/src/borrowers.ts
+++ b/services/microcredit/src/borrowers.ts
@@ -30,7 +30,7 @@ export async function updateBorrowers(): Promise<void> {
                 const borrower = borrowers.borrowers.find(el => el.id === user.address.toLowerCase());
                 const values = {
                     lastRepayment: borrower!.loan.lastRepayment,
-                    lastRepaymentAmount: parseFloat(borrower!.loan.lastRepaymentAmount),
+                    lastRepaymentAmount: borrower!.loan.lastRepaymentAmount ? parseFloat(borrower!.loan.lastRepaymentAmount) : 0,
                     lastDebt: parseFloat(borrower!.loan.lastDebt),
                     amount: parseFloat(borrower!.loan.amount),
                     period: borrower!.loan.period,


### PR DESCRIPTION
This PR fixes #911 

## Changes
Set `lastRepaymentAmount` 0 when is null on `subgraph_microcredit_borrowers`.
The staging and production lambdas have already been updated

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
