### PR TITLE
[bugfix] start listener after recover past events

### DIFF
--- a/packages/api/src/loaders/subscriber.ts
+++ b/packages/api/src/loaders/subscriber.ts
@@ -55,6 +55,7 @@ export function startSubscribers() {
     process.on('SIGINT', exitHandler.bind(null, { exit: true }));
     // catches dyno restart event
     process.on('SIGTERM', exitHandler.bind(null, { exit: true }));
+    process.on('SIGKILL', exitHandler.bind(null, { exit: true }));
     // catches "kill pid" (for example: nodemon restart)
     process.on('SIGUSR1', exitHandler.bind(null, { exit: true }));
     process.on('SIGUSR2', exitHandler.bind(null, { exit: true }));


### PR DESCRIPTION
no task.

## Changes
- start listener after recover post events
- to recover past events, first use the `recoverBlock`, then if don't exist, use the `lastBlock`.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
