### PR TITLE
[bugfix] fix the list communities order

### DIFF
--- a/packages/core/src/services/ubi/community/list.ts
+++ b/packages/core/src/services/ubi/community/list.ts
@@ -180,14 +180,16 @@ export class CommunityListService {
                         break;
                     default: {
                         if (query.status !== 'pending') {
-                            orderOption.push([literal('"state"."beneficiaries"'), orderType ? orderType : 'DESC']);
+                            const defaultOrder = 'DESC NULLS LAST';
+                            const order = orderType && orderType.toLowerCase() === 'desc' ? defaultOrder : orderType || defaultOrder;
+                            orderOption.push([literal('"state"."beneficiaries"'), order]);
                         }
                         break;
                     }
                 }
             }
         } else if (query.status !== 'pending' && (!query.fields || query.fields.indexOf('state') !== -1)) {
-            orderOption.push([literal('"state"."beneficiaries"'), 'DESC']);
+            orderOption.push([literal('"state"."beneficiaries"'), 'DESC NULLS LAST']);
         }
 
         let include: Includeable[];

--- a/packages/core/src/services/ubi/community/list.ts
+++ b/packages/core/src/services/ubi/community/list.ts
@@ -181,7 +181,10 @@ export class CommunityListService {
                     default: {
                         if (query.status !== 'pending') {
                             const defaultOrder = 'DESC NULLS LAST';
-                            const order = orderType && orderType.toLowerCase() === 'desc' ? defaultOrder : orderType || defaultOrder;
+                            const order =
+                                orderType && orderType.toLowerCase() === 'desc'
+                                    ? defaultOrder
+                                    : orderType || defaultOrder;
                             orderOption.push([literal('"state"."beneficiaries"'), order]);
                         }
                         break;


### PR DESCRIPTION
This PR fixes #gh-issue-number

## Changes
Fix the order in listing communities to return the `nulls` at the end.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
