### PR TITLE
[bugfix] fix applications results

### DIFF
--- a/packages/api/src/controllers/v2/microcredit/create.ts
+++ b/packages/api/src/controllers/v2/microcredit/create.ts
@@ -60,7 +60,7 @@ class MicroCreditController {
         }
 
         this.microCreditService
-            .postDocs(req.user.userId, req.body)
+            .postDocs(req.user.userId, req.body.applicationId, req.body.docs)
             .then(r => standardResponse(res, 201, true, r))
             .catch(e => standardResponse(res, 400, false, '', { error: e }));
     };

--- a/packages/api/src/routes/v2/microcredit/create.ts
+++ b/packages/api/src/routes/v2/microcredit/create.ts
@@ -57,19 +57,26 @@ export default (route: Router): void => {
      *       - "microcredit"
      *     summary: "Add microcredit related docs to a user"
      *     requestBody:
+     *       required: true
      *       content:
      *         application/json:
      *           schema:
-     *             type: array
-     *             items:
-     *               type: object
-     *               properties:
-     *                 filepath:
-     *                   type: string
-     *                   example: some/path/to/file.pdf
-     *                 category:
-     *                   type: number
-     *                   example: 1
+     *             type: object
+     *             properties:
+     *               applicationId:
+     *                 type: number
+     *                 required: true
+     *               docs:
+     *                 type: array
+     *                 items:
+     *                   type: object
+     *                   properties:
+     *                     filepath:
+     *                       type: string
+     *                       example: some/path/to/file.pdf
+     *                     category:
+     *                       type: number
+     *                       example: 1
      *     responses:
      *       "200":
      *         description: "Success"
@@ -92,6 +99,7 @@ export default (route: Router): void => {
      *     summary: "Update microcredit applications"
      *     description: "Status can be 0: pending, 1: submitted, 2: in-review, 3: requested-changes, 4: interview, 5: approved, 6: rejected"
      *     requestBody:
+     *       required: true
      *       content:
      *         application/json:
      *           schema:

--- a/packages/api/src/validators/microcredit.ts
+++ b/packages/api/src/validators/microcredit.ts
@@ -122,12 +122,15 @@ interface GetBorrowerRequestSchema extends ValidatedRequestSchema {
 // I wish this comes true https://github.com/hapijs/joi/issues/2864#issuecomment-1322736004
 
 // This should match Joi validations
-type PostDocsRequestType = [
-    {
-        filepath: string;
-        category: number;
-    }
-];
+type PostDocsRequestType = {
+    applicationId: number;
+    docs: [
+        {
+            filepath: string;
+            category: number;
+        }
+    ];
+};
 type PutApplicationsRequestType = [
     {
         applicationId: number;
@@ -142,13 +145,17 @@ const preSignerUrlFromAWSValidator = validator.query(queryPreSignerUrlFromAWSSch
 const queryGetBorrowerValidator = validator.query(queryGetBorrowerSchema);
 const postDocsValidator = celebrate({
     body: defaultSchema
-        .array<PostDocsRequestType>()
-        .items(
-            Joi.object({
-                filepath: Joi.string().required(),
-                category: Joi.number().required()
-            }).required()
-        )
+        .object<PostDocsRequestType>({
+            applicationId: Joi.number().required(),
+            docs: Joi.array()
+                .items(
+                    Joi.object({
+                        filepath: Joi.string().required(),
+                        category: Joi.number().required()
+                    })
+                )
+                .required()
+        })
         .required()
 });
 const putApplicationsValidator = celebrate({

--- a/packages/core/src/database/migrations/z20230517134015-create-micro-credit-docs.js
+++ b/packages/core/src/database/migrations/z20230517134015-create-micro-credit-docs.js
@@ -13,6 +13,10 @@ module.exports = {
                 type: Sequelize.INTEGER,
                 allowNull: false
             },
+            applicationId: {
+                type: Sequelize.INTEGER,
+                allowNull: false
+            },
             category: {
                 allowNull: false,
                 type: Sequelize.INTEGER

--- a/packages/core/src/database/migrations/z20230609115751-create-micro-credit-applications.js
+++ b/packages/core/src/database/migrations/z20230609115751-create-micro-credit-applications.js
@@ -46,6 +46,14 @@ module.exports = {
                 allowNull: true,
                 type: Sequelize.DATE
             },
+            signedOn: {
+                allowNull: true,
+                type: Sequelize.DATE
+            },
+            claimedOn: {
+                allowNull: true,
+                type: Sequelize.DATE
+            },
             createdAt: {
                 allowNull: false,
                 type: Sequelize.DATE

--- a/packages/core/src/database/migrations/z20231006144016-update-micro-credit-docs.js
+++ b/packages/core/src/database/migrations/z20231006144016-update-micro-credit-docs.js
@@ -1,0 +1,35 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn('microcredit_docs', 'applicationId', {
+            type: Sequelize.INTEGER,
+            allowNull: true
+        });
+
+        await queryInterface.sequelize.query(`
+            UPDATE microcredit_docs
+            SET "applicationId" = (
+                SELECT id
+                FROM microcredit_applications
+                WHERE microcredit_applications."userId" = microcredit_docs."userId"
+                ORDER BY "createdAt" DESC
+                LIMIT 1
+            )
+            WHERE "applicationId" IS NULL
+        `);
+
+        await queryInterface.sequelize.query(`
+            DELETE from microcredit_docs
+            WHERE "applicationId" IS NULL
+        `);
+
+        await queryInterface.changeColumn('microcredit_docs', 'applicationId', {
+            type: Sequelize.INTEGER,
+            allowNull: false
+        });
+    },
+    async down(queryInterface, Sequelize) {
+        //
+    }
+};

--- a/packages/core/src/database/migrations/z20231006144016-update-micro-credit-docs.js
+++ b/packages/core/src/database/migrations/z20231006144016-update-micro-credit-docs.js
@@ -2,6 +2,10 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
     async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+        
         await queryInterface.addColumn('microcredit_docs', 'applicationId', {
             type: Sequelize.INTEGER,
             allowNull: true

--- a/packages/core/src/database/migrations/z20231010100635-update-micro-credit-applications.js
+++ b/packages/core/src/database/migrations/z20231010100635-update-micro-credit-applications.js
@@ -1,0 +1,18 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn('microcredit_applications', 'signedOn', {
+            allowNull: true,
+            type: Sequelize.DATE
+        });
+
+        await queryInterface.addColumn('microcredit_applications', 'claimedOn', {
+            allowNull: true,
+            type: Sequelize.DATE
+        });
+    },
+    async down(queryInterface, Sequelize) {
+        //
+    }
+};

--- a/packages/core/src/database/migrations/z20231010100635-update-micro-credit-applications.js
+++ b/packages/core/src/database/migrations/z20231010100635-update-micro-credit-applications.js
@@ -2,6 +2,10 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
     async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+
         await queryInterface.addColumn('microcredit_applications', 'signedOn', {
             allowNull: true,
             type: Sequelize.DATE

--- a/packages/core/src/database/migrations/z20231010145251-update-micro-credit-applications.js
+++ b/packages/core/src/database/migrations/z20231010145251-update-micro-credit-applications.js
@@ -1,0 +1,33 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        // update microcredit_applications setting signedOn to each user, based on when the user uploaded a doc to microcredit_docs with category 1
+        await queryInterface.sequelize.query(`
+            UPDATE microcredit_applications
+            SET "signedOn" = (
+                SELECT "createdAt"
+                FROM microcredit_docs
+                WHERE microcredit_docs."userId" = microcredit_applications."userId"
+                AND microcredit_docs."category" = 1
+                ORDER BY "createdAt" DESC
+                LIMIT 1
+            )
+        `);
+
+        // update microcredit_applications setting claimedOn to each user, based on when the user claimed the loan, getting that info from "claimed" on subgraph_microcredit_borrowers
+        await queryInterface.sequelize.query(`
+            UPDATE microcredit_applications
+            SET "claimedOn" = (
+                SELECT to_timestamp("claimed")::timestamptz
+                FROM subgraph_microcredit_borrowers
+                WHERE subgraph_microcredit_borrowers."userId" = microcredit_applications."userId"
+                ORDER BY "createdAt" DESC
+                LIMIT 1
+            )
+        `);
+    },
+    async down(queryInterface, Sequelize) {
+        //
+    }
+};

--- a/packages/core/src/database/migrations/z20231010145251-update-micro-credit-applications.js
+++ b/packages/core/src/database/migrations/z20231010145251-update-micro-credit-applications.js
@@ -2,6 +2,10 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
     async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+        
         // update microcredit_applications setting signedOn to each user, based on when the user uploaded a doc to microcredit_docs with category 1
         await queryInterface.sequelize.query(`
             UPDATE microcredit_applications

--- a/packages/core/src/database/migrations/z20231010145301-update-micro-credit-docs.js
+++ b/packages/core/src/database/migrations/z20231010145301-update-micro-credit-docs.js
@@ -2,6 +2,10 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
     async up(queryInterface, Sequelize) {
+        if (process.env.NODE_ENV === 'test') {
+            return;
+        }
+
         await queryInterface.sequelize.query(`
             DELETE FROM microcredit_docs AS t1
                 WHERE id NOT IN (

--- a/packages/core/src/database/migrations/z20231010145301-update-micro-credit-docs.js
+++ b/packages/core/src/database/migrations/z20231010145301-update-micro-credit-docs.js
@@ -1,0 +1,19 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.query(`
+            DELETE FROM microcredit_docs AS t1
+                WHERE id NOT IN (
+                SELECT id
+                FROM microcredit_docs AS t2
+                WHERE t1."applicationId" = t2."applicationId"
+                    AND t1.category = t2.category
+                    AND t1.id < t2.id
+                );
+        `);
+    },
+    async down(queryInterface, Sequelize) {
+        //
+    }
+};

--- a/packages/core/src/database/models/index.ts
+++ b/packages/core/src/database/models/index.ts
@@ -134,8 +134,8 @@ export default function initModels(sequelize: Sequelize): void {
     initializeLearnAndEarnUserData(sequelize);
 
     // MicroCredit
-    initializeMicroCreditDocs(sequelize);
     initializeMicroCreditApplication(sequelize);
+    initializeMicroCreditDocs(sequelize);
     initializeMicroCreditBorrowers(sequelize);
     initializeMicroCreditBorrowersHuma(sequelize);
     initializeMicroCreditNote(sequelize);

--- a/packages/core/src/database/models/microCredit/applications.ts
+++ b/packages/core/src/database/models/microCredit/applications.ts
@@ -3,6 +3,8 @@ import { DataTypes, Model, Sequelize } from 'sequelize';
 import { AppUserModel } from '../app/appUser';
 import { DbModels } from '../../../database/db';
 import { MicroCreditApplication, MicroCreditApplicationCreation } from '../../../interfaces/microCredit/applications';
+import { MicroCreditDocsModel } from './docs';
+import { SubgraphMicroCreditBorrowersModel } from './subgraphBorrowers';
 
 export class MicroCreditApplicationModel extends Model<MicroCreditApplication, MicroCreditApplicationCreation> {
     public id!: number;
@@ -14,12 +16,16 @@ export class MicroCreditApplicationModel extends Model<MicroCreditApplication, M
     public period!: number;
     public status!: number;
     public decisionOn!: Date;
+    public signedOn!: Date;
+    public claimedOn!: Date;
 
     // timestamps!
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
 
     public readonly user?: AppUserModel;
+    public readonly docs?: MicroCreditDocsModel[];
+    public readonly borrower?: SubgraphMicroCreditBorrowersModel;
 }
 
 export function initializeMicroCreditApplication(sequelize: Sequelize): typeof MicroCreditApplicationModel {
@@ -65,6 +71,14 @@ export function initializeMicroCreditApplication(sequelize: Sequelize): typeof M
                 type: DataTypes.INTEGER
             },
             decisionOn: {
+                allowNull: true,
+                type: DataTypes.DATE
+            },
+            signedOn: {
+                allowNull: true,
+                type: DataTypes.DATE
+            },
+            claimedOn: {
                 allowNull: true,
                 type: DataTypes.DATE
             },

--- a/packages/core/src/database/models/microCredit/docs.ts
+++ b/packages/core/src/database/models/microCredit/docs.ts
@@ -6,6 +6,7 @@ import { MicroCreditDocs, MicroCreditDocsCreationAttributes } from '../../../int
 export class MicroCreditDocsModel extends Model<MicroCreditDocs, MicroCreditDocsCreationAttributes> {
     public id!: number;
     public userId!: number;
+    public applicationId!: number;
     public category!: number;
     public filepath!: string;
 
@@ -15,7 +16,7 @@ export class MicroCreditDocsModel extends Model<MicroCreditDocs, MicroCreditDocs
 }
 
 export function initializeMicroCreditDocs(sequelize: Sequelize): typeof MicroCreditDocsModel {
-    const { appUser } = sequelize.models as DbModels;
+    const { appUser, microCreditApplications } = sequelize.models as DbModels;
     MicroCreditDocsModel.init(
         {
             id: {
@@ -27,6 +28,15 @@ export function initializeMicroCreditDocs(sequelize: Sequelize): typeof MicroCre
                 type: DataTypes.INTEGER,
                 references: {
                     model: appUser,
+                    key: 'id'
+                },
+                onDelete: 'CASCADE',
+                allowNull: false
+            },
+            applicationId: {
+                type: DataTypes.INTEGER,
+                references: {
+                    model: microCreditApplications,
                     key: 'id'
                 },
                 onDelete: 'CASCADE',
@@ -52,7 +62,14 @@ export function initializeMicroCreditDocs(sequelize: Sequelize): typeof MicroCre
         {
             tableName: 'microcredit_docs',
             modelName: 'microCreditDocs',
-            sequelize
+            sequelize,
+            // ensure that applicationId + category is unique
+            indexes: [
+                {
+                    unique: true,
+                    fields: ['applicationId', 'category']
+                }
+            ]
         }
     );
     return MicroCreditDocsModel;

--- a/packages/core/src/interfaces/microCredit/applications.ts
+++ b/packages/core/src/interfaces/microCredit/applications.ts
@@ -8,6 +8,8 @@ export interface MicroCreditApplication {
     period: number;
     status: number;
     decisionOn: Date;
+    signedOn: Date;
+    claimedOn: Date;
 
     // timestamps
     createdAt: Date;

--- a/packages/core/src/interfaces/microCredit/docs.ts
+++ b/packages/core/src/interfaces/microCredit/docs.ts
@@ -1,6 +1,7 @@
 export interface MicroCreditDocs {
     id: number;
     userId: number;
+    applicationId: number;
     category: number;
     filepath: string;
 
@@ -11,6 +12,7 @@ export interface MicroCreditDocs {
 
 export interface MicroCreditDocsCreationAttributes {
     userId: number;
+    applicationId: number;
     category: number;
     filepath: string;
 }

--- a/packages/core/src/services/microcredit/list.ts
+++ b/packages/core/src/services/microcredit/list.ts
@@ -240,11 +240,11 @@ export default class MicroCreditList {
             avatarMediaPath: string | null;
             // from models.microCreditApplications
             application: {
-                amount: number;
-                period: number;
                 appliedOn: Date;
+                decisionOn?: Date;
+                signedOn?: Date;
+                claimedOn?: Date;
                 status: number;
-                decisionOn: Date;
             };
         }[];
     }> => {
@@ -276,7 +276,7 @@ export default class MicroCreditList {
             };
         }
         const applications = await models.microCreditApplications.findAndCountAll({
-            attributes: ['id', 'amount', 'period', 'status', 'decisionOn', 'createdAt'],
+            attributes: ['id', 'amount', 'period', 'status', 'decisionOn', 'signedOn', 'claimedOn', 'createdAt'],
             where,
             include: [
                 {

--- a/packages/core/tests/integration/v2/microcredit.test.ts
+++ b/packages/core/tests/integration/v2/microcredit.test.ts
@@ -32,7 +32,7 @@ describe('microCredit', () => {
 
     describe('docs', () => {
         it('create and list', async () => {
-            await microCreditCreate.postDocs(users[0].id, [
+            await microCreditCreate.postDocs(users[0].id, 1, [
                 {
                     filepath: 'test',
                     category: 1

--- a/packages/worker/src/chainSubscribers.ts
+++ b/packages/worker/src/chainSubscribers.ts
@@ -39,6 +39,7 @@ class ChainSubscribers {
                 ethers.utils.id('CommunityRemoved(address)'),
                 ethers.utils.id('BeneficiaryAdded(address,address)'),
                 ethers.utils.id('BeneficiaryRemoved(address,address)'),
+                ethers.utils.id('LoanClaimed(address,uint256)'),
                 ethers.utils.id('LoanAdded(address,uint256,uint256,uint256,uint256,uint256)'),
                 ethers.utils.id('ManagerChanged(address,address)'),
                 ethers.utils.id('Transfer(address,address,uint256)')
@@ -437,6 +438,22 @@ class ChainSubscribers {
                         );
                     }
                 }
+            } else if (parsedLog.name === 'LoanClaimed') {
+                utils.Logger.info('Claim Loan event');
+                const parsedLog = this.ifaceMicrocredit.parseLog(log);
+                const userAddress = parsedLog.args[0];
+
+                await database.models.microCreditApplications.update(
+                    {
+                        claimedOn: new Date()
+                    },
+                    {
+                        where: {
+                            userId: userAddress
+                        },
+                        transaction
+                    }
+                );
             } else if (parsedLog.name === 'ManagerChanged') {
                 utils.Logger.info('ManagerChanged event');
 


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR fixes the response on `GET /microcredit/applications` so that it includes all the data to be added on the dashboard.

To accommodate that, two new columns were added. The reason behind those two columns was to avoid two LEFT JOINs.

```typescript
const applications = await models.microCreditApplications.findAndCountAll({
    attributes: ['id', 'amount', 'period', 'status', 'decisionOn', 'createdAt'],
    where,
    include: [
        {
            model: models.appUser,
            as: 'user',
            attributes: ['address', 'firstName', 'lastName', 'avatarMediaPath']
        },
        {
            model: models.microCreditDocs,
            as: 'docs',
            attributes: [],
            // only the document with category type 1 (might not exist)
            where: {
                category: 1
            },
            required: false
        },
        {
            model: models.subgraphMicroCreditBorrowers,
            as: 'borrower',
            attributes: ['claim'],
            required: false
        }
    ],
    order: [[orderKey || 'microCreditApplications.createdAt', orderDirection || 'desc']],
    offset: query.offset,
    limit: query.limit
});
```

It also changes `POST /microcredit/docs`, requiring the applicationId.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
