### PR TITLE
[chore] rewrite chainSubscriber listener

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     },
     "scripts": {
         "dev": "lerna exec --scope @impactmarket/api yarn dev",
+        "dev:worker": "lerna exec --scope @impactmarket/worker yarn dev",
         "start": "node --require './packages/api/appsignal.cjs' packages/api/dist/app.js",
         "worker": "node packages/worker/dist/index.js",
         "build": "lerna exec --scope @impactmarket/api --scope @impactmarket/core --scope @impactmarket/worker yarn build",


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR rewrites the listener on `chainSubscriber`, reducing required processing. It also changes the `_runRecoveryTxs` to get batches of events, up to 100 blocks.

Currently, with log level `info`, running the `chainSubscriber` on alfajores gives us the following

```bash
info:    Starting subscribers...
info:    Receiving new event
info:    Processing logs (20368522) (1 txs)...

QUERY: Executed (7e684d59-94bc-473d-a83c-af42bd1c12f8): START TRANSACTION; TIME: 52ms

QUERY: Executed (7e684d59-94bc-473d-a83c-af42bd1c12f8): COMMIT; TIME: 51ms
info:    Logs processed! Elapsed: 160ms
info:    Receiving new event
info:    Processing logs (20368526) (1 txs)...

QUERY: Executed (d1c78215-beef-4633-ad31-e9d83c62a402): START TRANSACTION; TIME: 54ms

QUERY: Executed (d1c78215-beef-4633-ad31-e9d83c62a402): COMMIT; TIME: 59ms
info:    Logs processed! Elapsed: 168ms
info:    Receiving new event
info:    Processing logs (20368527) (1 txs)...

QUERY: Executed (4cdd8d8f-6710-4b55-93cc-2b17e2e9b7aa): START TRANSACTION; TIME: 56ms

QUERY: Executed (4cdd8d8f-6710-4b55-93cc-2b17e2e9b7aa): COMMIT; TIME: 53ms
info:    Logs processed! Elapsed: 184ms

QUERY: Executed (default): UPDATE "immetadata" SET "value"=$1,"updatedAt"=$2 WHERE "key" = $3 TIME: 58ms
```

This shows that on every block, a new transaction is started and closed, spending processing power, without doing any change because now event was found. It actually seems like that, on every block, creating connections and doing validations for nothing. When we look at mainnet, things are a bit more worrying.
```
2023-10-16T13:21:30.726386+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726510+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726544+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726558+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726568+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726579+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726590+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726602+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726613+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726627+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726637+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726646+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726658+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726673+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726706+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726718+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726728+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726739+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726750+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726762+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726773+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726784+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726795+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726806+00:00 app[worker.1]: info:    Receiving new event
2023-10-16T13:21:30.726886+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727439+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727471+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727488+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727521+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727537+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727551+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727565+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727580+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727593+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727608+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727622+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727637+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727653+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727671+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727691+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727705+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727719+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727732+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727746+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727772+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727785+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727795+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.727824+00:00 app[worker.1]: info:    Processing logs (21958778) (1 txs)...
2023-10-16T13:21:30.732854+00:00 app[worker.1]: info:    Logs processed! Elapsed: 5ms
2023-10-16T13:21:30.732885+00:00 app[worker.1]: info:    Logs processed! Elapsed: 5ms
2023-10-16T13:21:30.732912+00:00 app[worker.1]: info:    Logs processed! Elapsed: 5ms
2023-10-16T13:21:30.732944+00:00 app[worker.1]: info:    Logs processed! Elapsed: 5ms
2023-10-16T13:21:30.732975+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733033+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733058+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733145+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733319+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733386+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733416+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733497+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733541+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733594+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733624+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733668+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733694+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733718+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733751+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733827+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733925+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733956+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.733988+00:00 app[worker.1]: info:    Logs processed! Elapsed: 6ms
2023-10-16T13:21:30.734177+00:00 app[worker.1]: info:    Logs processed! Elapsed: 7ms
```

In this case, 24 transactions were started and closed, without any change. On top of that, this should actually be happening just once.

So, after some initial changes and verifying if there are logs on a block to be processed, with `_preFilterAndProcessEvent`, it somewhat improved, but there was still logs processed to each block and too many `immetada` updates when it should only be updated every 23 hours.

```bash
info:    Starting subscribers...
info:    Receiving new event
info:    Processing logs (20368616) (1 txs)...
info:    Logs processed! Elapsed: 51ms
info:    Receiving new event
info:    Processing logs (20368620) (1 txs)...
info:    Logs processed! Elapsed: 52ms
info:    Receiving new event
info:    Processing logs (20368622) (1 txs)...
info:    Logs processed! Elapsed: 60ms

QUERY: Executed (default): UPDATE "immetadata" SET "value"=$1,"updatedAt"=$2 WHERE "key" = $3 TIME: 60ms
info:    Receiving new event
info:    Processing logs (20368624) (1 txs)...
info:    Logs processed! Elapsed: 59ms
info:    Receiving new event
info:    Processing logs (20368626) (1 txs)...
info:    Logs processed! Elapsed: 62ms
info:    Receiving new event
info:    Processing logs (20368628) (1 txs)...
info:    Logs processed! Elapsed: 53ms

QUERY: Executed (default): UPDATE "immetadata" SET "value"=$1,"updatedAt"=$2 WHERE "key" = $3 TIME: 61ms
info:    Receiving new event
info:    Processing logs (20368630) (1 txs)...
info:    Logs processed! Elapsed: 55ms
info:    Receiving new event
info:    Receiving new event
info:    Processing logs (20368632) (1 txs)...
info:    Processing logs (20368632) (1 txs)...
info:    Logs processed! Elapsed: 54ms
info:    Logs processed! Elapsed: 53ms
info:    Receiving new event
info:    Processing logs (20368634) (1 txs)...
info:    Logs processed! Elapsed: 55ms

QUERY: Executed (default): UPDATE "immetadata" SET "value"=$1,"updatedAt"=$2 WHERE "key" = $3 TIME: 56ms
```

After that, I decided to rewrite the listener. The results now are as follows
```bash
info:    Starting subscribers...

QUERY: Executed (default): SELECT "key", "value", "createdAt", "updatedAt" FROM "immetadata" AS "imMetadata" WHERE "imMetadata"."key" = 'lastBlock'; TIME: 55ms
{ blockNumber: 20414748 }
{ blockNumber: 20414749 }
{ blockNumber: 20414750 }
{ blockNumber: 20414751 }
{ blockNumber: 20414752 }
{ hasValidEvent: true }
{ blockNumber: 20414753 }
Map(1) {
  20414752 => [
    {
      blockNumber: 20414752,
      blockHash: '0xfd14f790f0864d47724c1a26e3ead8d0a70a6e7a31725c4b4b0e65a42eede25c',
      transactionIndex: 0,
      removed: false,
      address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
      data: '0x000000000000000000000000000000000000000000000000002386f26fc10000',
      topics: [Array],
      transactionHash: '0x2386e09d7cc5e96bbe9019bfe19c6a595760aa655632c59d74996dfd34c4039d',
      logIndex: 0
    }
  ]
}
info:    Processing logs (20414752) (1 txs)...

QUERY: Executed (f06fc92b-5bf2-4e8c-805b-ea6d2d187ed0): START TRANSACTION; TIME: 51ms
info:    Receiving event from Transfer (cUSD)
info:    Event processed! Elapsed: 1ms

QUERY: Executed (f06fc92b-5bf2-4e8c-805b-ea6d2d187ed0): COMMIT; TIME: 63ms
info:    Logs processed! Elapsed: 503ms
{ blockNumber: 20414754 }
{ blockNumber: 20414755 }
{ blockNumber: 20414756 }
{ blockNumber: 20414757 }
{ blockNumber: 20414758 }
{ blockNumber: 20414759 }
{ blockNumber: 20414760 }
{ blockNumber: 20414761 }
{ blockNumber: 20414762 }
{ blockNumber: 20414763 }
{ hasValidEvent: true }
{ blockNumber: 20414764 }
Map(1) {
  20414763 => [
    {
      blockNumber: 20414763,
      blockHash: '0x5a83f3a64f99043c37c08a71488e16b4fb8afaaf2282a4a51f07aa90d269cc05',
      transactionIndex: 0,
      removed: false,
      address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
      data: '0x000000000000000000000000000000000000000000000000002386f26fc10000',
      topics: [Array],
      transactionHash: '0xb6126465e8613dd02aaaea72759c128a5143ffdc4d0c333f7356a3c92b963abd',
      logIndex: 0
    }
  ]
}
info:    Processing logs (20414763) (1 txs)...

QUERY: Executed (87dca847-fc03-4e5e-9889-9221d4e0a8ca): START TRANSACTION; TIME: 50ms
info:    Receiving event from Transfer (cUSD)
info:    Event processed! Elapsed: 0ms

QUERY: Executed (87dca847-fc03-4e5e-9889-9221d4e0a8ca): COMMIT; TIME: 51ms
info:    Logs processed! Elapsed: 600ms
{ blockNumber: 20414765 }
{ blockNumber: 20414766 }
{ blockNumber: 20414767 }
```

These are two cUSD transaction from a beneficiary, being processed on the block after they've happened. There could have been a lot of transactions being processed. It would still be only one database transaction, processed in parallel to new events listening. In this case, the cUSD event was no processed, only printed the logs for test purposes.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
Manual as seen above.