### PR TITLE
[bugfix] invalid "total lessons"

### DIFF
--- a/packages/core/src/services/learnAndEarn/userData.ts
+++ b/packages/core/src/services/learnAndEarn/userData.ts
@@ -4,7 +4,7 @@ import { BaseError } from '../../utils/baseError';
 import { models, redisClient } from '../../database';
 
 async function countAllLevelsAndLessons(clientId: number, language: string) {
-    const cacheResults = await redisClient.get('countAllLevelsAndLessons');
+    const cacheResults = await redisClient.get(`countAllLevelsAndLessons/${clientId}`);
 
     if (cacheResults) {
         return JSON.parse(cacheResults);
@@ -41,7 +41,7 @@ async function countAllLevelsAndLessons(clientId: number, language: string) {
     };
 
     // this is deleted when there's an update
-    await redisClient.set('countAllLevelsAndLessons', JSON.stringify(result), 'EX', 60 * 60 * 6);
+    await redisClient.set(`countAllLevelsAndLessons/${clientId}`, JSON.stringify(result), 'EX', 60 * 60 * 6);
 
     return result;
 }


### PR DESCRIPTION
![Screenshot 2023-10-20 at 17 43 48](https://github.com/impactMarket/backend/assets/20671594/11a11e23-4b0d-49ca-aaef-329b052e2e88)

## Changes
total of lessons is being cached without considering the clientID

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
