### PR TITLE
[bugfix] adding a combination of columns to order the borrowers

### DIFF
--- a/packages/core/src/services/microcredit/list.ts
+++ b/packages/core/src/services/microcredit/list.ts
@@ -119,7 +119,11 @@ export default class MicroCreditList {
         // build up database queries based on query params
         if (query.orderBy && query.orderBy.indexOf('performance') !== -1) {
             order = [
-                // Adding a combination of columns to ensure unique and stable ordering. This prevents duplicates and missing records during pagination.
+                // Adding a combination of columns to ensure unique and stable ordering.
+                // When sorting using columns like `lastRepayment` or `performance`, many records will have the same value (0 or NULL).
+                // If multiple records share the same value in the sorting column, PostgreSQL may have difficulty determining how to paginate the results consistently
+                // and some records may appear multiple times, and others might not be listed.
+                // To address this, the `userId` column is concatenate to the ordering received in the request, creating a unique composite for sorting.
                 [literal('performance'), query.orderBy.indexOf('asc') !== -1 ? 'ASC' : 'DESC'],
                 [literal('"microCreditBorrowers"."userId"'), 'ASC']
             ];

--- a/packages/core/src/services/microcredit/list.ts
+++ b/packages/core/src/services/microcredit/list.ts
@@ -118,10 +118,17 @@ export default class MicroCreditList {
 
         // build up database queries based on query params
         if (query.orderBy && query.orderBy.indexOf('performance') !== -1) {
-            order = [[literal('performance'), query.orderBy.indexOf('asc') !== -1 ? 'ASC' : 'DESC']];
+            order = [
+                // Adding a combination of columns to ensure unique and stable ordering. This prevents duplicates and missing records during pagination.
+                [literal('performance'), query.orderBy.indexOf('asc') !== -1 ? 'ASC' : 'DESC'],
+                [literal('"microCreditBorrowers"."userId"'), 'ASC'] 
+            ];
         } else if (query.orderBy) {
             const [field, direction] = query.orderBy.split(':');
-            order = [[literal(`"loan.${field}"`), direction || 'ASC']];
+            order = [
+                [literal(`"loan.${field}"`), direction || 'ASC'],
+                [literal('"microCreditBorrowers"."userId"'), 'ASC']
+            ];
         }
 
         if (query.filter === 'ontrack') {

--- a/packages/core/src/services/microcredit/list.ts
+++ b/packages/core/src/services/microcredit/list.ts
@@ -121,7 +121,7 @@ export default class MicroCreditList {
             order = [
                 // Adding a combination of columns to ensure unique and stable ordering. This prevents duplicates and missing records during pagination.
                 [literal('performance'), query.orderBy.indexOf('asc') !== -1 ? 'ASC' : 'DESC'],
-                [literal('"microCreditBorrowers"."userId"'), 'ASC'] 
+                [literal('"microCreditBorrowers"."userId"'), 'ASC']
             ];
         } else if (query.orderBy) {
             const [field, direction] = query.orderBy.split(':');


### PR DESCRIPTION
## Changes
On the list borrowers, some of them were not listed, and others appeared duplicated.
This occurs when we use a column as a sort (like`lastRepayment`) that has many registries with the same value (0).
To fix this problem, the `userId` will be concatenated together with the requested order, to form a combination of columns and ensure a unique ordering

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
