### PR TITLE
[bugfix] clear borrower cache when adding note

### DIFF
--- a/packages/api/src/routes/v2/microcredit/list.ts
+++ b/packages/api/src/routes/v2/microcredit/list.ts
@@ -116,7 +116,7 @@ export default (route: Router): void => {
         '/borrower/:query?',
         authenticateToken,
         verifySignature,
-        cache(cacheIntervals.tenMinutes, true),
+        cache(cacheIntervals.tenMinutes, false),
         onlyAuthorizedRoles(['loanManager', 'itself']),
         queryGetBorrowerValidator,
         controller.getBorrower

--- a/packages/core/src/services/microcredit/create.ts
+++ b/packages/core/src/services/microcredit/create.ts
@@ -12,7 +12,7 @@ import { MicroCreditContentStorage } from '../../services/storage';
 import { NotificationParamsPath, NotificationType } from '../../interfaces/app/appNotification';
 import { NullishPropertiesOf } from 'sequelize/types/utils';
 import { Op, Optional, Transaction, WhereOptions } from 'sequelize';
-import { cleanMicroCreditApplicationsCache } from '../../utils/cache';
+import { cleanMicroCreditApplicationsCache, cleanMicroreditBorrowerCache } from '../../utils/cache';
 import { config } from '../../..';
 import { models } from '../../database';
 import { sendEmail } from '../../services/email';
@@ -298,12 +298,26 @@ export default class MicroCreditCreate {
         }
     };
 
-    public addNote = (managerId: number, userId: number, note: string) => {
-        return models.microCreditNote.create({
+    public addNote = async (managerId: number, userId: number, note: string) => {
+        const newNote = await models.microCreditNote.create({
             managerId,
             userId,
             note
         });
+
+        if (!newNote) {
+            throw new BaseError('ADD_NOTE_ERROR', 'Error adding note');
+        }
+
+        // clear borrower cache
+        models.appUser
+            .findOne({
+                attributes: ['address'],
+                where: { id: userId }
+            })
+            .then(user => user && cleanMicroreditBorrowerCache(user.address));
+
+        return newNote;
     };
 
     private async _notifyApplicationChangeStatusByEmail(

--- a/packages/core/src/utils/cache.ts
+++ b/packages/core/src/utils/cache.ts
@@ -45,3 +45,12 @@ export const cleanMicroCreditApplicationsCache = async (userId?: number) => {
         redisClient.del(key);
     });
 };
+
+export const cleanMicroreditBorrowerCache = async (borrowerAddress: string) => {
+    const cachedBody = await redisClient.keys(
+        '__express__/api/v2/microcredit/borrower*address=' + borrowerAddress + '*'
+    );
+    cachedBody.forEach(key => {
+        redisClient.del(key);
+    });
+};


### PR DESCRIPTION
## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

This PR clears cache on borrower endpoint when adding a new note, so the results are immediately updated.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
