### PR TITLE
fix calculate global metrics

### DIFF
--- a/packages/core/src/subgraph/config.ts
+++ b/packages/core/src/subgraph/config.ts
@@ -7,21 +7,21 @@ const axiosSubgraph = axios.create({
     headers: {
         'content-type': 'application/json'
     },
-    timeout: 5000
+    timeout: 10000
 });
 const axiosCouncilSubgraph = axios.create({
     baseURL: config.councilSubgraphUrl,
     headers: {
         'content-type': 'application/json'
     },
-    timeout: 5000
+    timeout: 10000
 });
 const axiosMicrocreditSubgraph = axios.create({
     baseURL: config.microcreditSubgraphUrl,
     headers: {
         'content-type': 'application/json'
     },
-    timeout: 5000
+    timeout: 10000
 });
 // TODO: " as any" is a temporary solution to deploy to heroku
 // TODO: test this works as expected to reduce timeout

--- a/services/community-metrics/handler.ts
+++ b/services/community-metrics/handler.ts
@@ -21,8 +21,8 @@ export const calculate = async (event, context) => {
     const today = new Date();
 
     if (today.getHours() <= 1) {
+        await calcuateCommunitiesMetrics(); // community metrics must be executed before all others
         await Promise.all([
-            calcuateCommunitiesMetrics(),
             calcuateGlobalMetrics(),
             calcuateCommunitiesDemographics(),
             calculateGlobalDemographics()

--- a/services/community-metrics/src/calcuateGlobalMetrics.ts
+++ b/services/community-metrics/src/calcuateGlobalMetrics.ts
@@ -1,4 +1,4 @@
-import { Op, col, fn } from 'sequelize';
+import { Op, col, fn, literal } from 'sequelize';
 import {
     config,
     database,
@@ -224,8 +224,8 @@ async function calculateUbiPulse(
                 attributes: [
                     [fn('avg', col('ubiRate')), 'avgUbiRate'],
                     [
-                        fn('avg', col('estimatedDuration')),
-                        'avgEstimatedDuration',
+                        literal('AVG(CASE WHEN "estimatedDuration" < 10e5 THEN "estimatedDuration" ELSE NULL END)'),  // ignore outliers
+                        'avgEstimatedDuration'
                     ],
                 ],
                 where: {

--- a/services/community-metrics/src/calcuateGlobalMetrics.ts
+++ b/services/community-metrics/src/calcuateGlobalMetrics.ts
@@ -246,7 +246,7 @@ async function calculateUbiPulse(
     const getAvgComulativeUbi = async (): Promise<string> => {
         const communityFoundingRate =
             await subgraph.queries.community.communityEntities(
-                `where: { state_not: 2 }, first: 1000`,
+                `where: { state_not: 2, maxClaim_lt: 5000 }, first: 1000`,
                 `maxClaim`
             );
         const comulativeUbi = communityFoundingRate.reduce(


### PR DESCRIPTION
This PR fixes #gh-issue-number

## Changes
Fix calculate global metrics:
- increase axios timeout to 10s
- execute calcuateCommunitiesMetrics before others
- remove "outliers" (communities with high maxClaim)

Lambda deploy already done
## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
