### PR TITLE
[bugfix] fix one-time repayment rate

### DIFF
--- a/packages/core/src/contracts/MicrocreditABI.json
+++ b/packages/core/src/contracts/MicrocreditABI.json
@@ -223,5 +223,79 @@
       }
     ],
     "anonymous": false
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_userAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_loanId",
+        "type": "uint256"
+      }
+    ],
+    "name": "userLoans",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountBorrowed",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "period",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "dailyInterest",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "claimDeadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "startDate",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "currentDebt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastComputedDebt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountRepayed",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "repaymentsLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastComputedDate",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "managerAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/packages/core/src/database/models/app/appUser.ts
+++ b/packages/core/src/database/models/app/appUser.ts
@@ -34,7 +34,7 @@ export class AppUserModel extends Model<AppUser, AppUserCreationAttributes> {
     public readonly updatedAt!: Date;
     public readonly deletedAt!: Date;
 
-    public readonly borrower?: MicroCreditBorrowersModel;
+    public readonly borrower?: MicroCreditBorrowersModel[];
     public readonly microCreditApplications?: MicroCreditApplicationModel[];
 }
 

--- a/packages/core/src/database/models/associations/user.ts
+++ b/packages/core/src/database/models/associations/user.ts
@@ -33,7 +33,7 @@ export function userAssociation(sequelize: Sequelize) {
         as: 'user'
     });
 
-    appUser.hasOne(microCreditBorrowers, {
+    appUser.hasMany(microCreditBorrowers, {
         foreignKey: 'userId',
         sourceKey: 'id',
         as: 'borrower'


### PR DESCRIPTION
This PR fixes one-time repayments rate.

## Changes
<!---
Describe the changes/feature. If there are many changes, create groups.
This change sometimes imply frontend changes, please be clear.
Specify what's new. New endpoints, etc.
-->

One-time repayments rate have a little trick. They should show on "late repayment" only a few days before maturity. Which is different from the weekly or monthly. Also, the actual "time" for that rate can only be calculated when the borrower claims the loan. 

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
Manually with borrower 3