### PR TITLE
[bugfix] get community

### DIFF
--- a/packages/api/src/controllers/v2/community/details.ts
+++ b/packages/api/src/controllers/v2/community/details.ts
@@ -99,8 +99,19 @@ class CommunityController {
                 .then(community => standardResponse(res, 200, !!community, community))
                 .catch(e => standardResponse(res, 400, false, '', { error: e }));
         } else {
+            const communityId = parseInt(idOrAddress, 10);
+            if (!communityId) {
+                standardResponse(res, 400, false, '', {
+                    error: {
+                        name: 'INVALID_PARAMS',
+                        message: 'community ID or address is expected'
+                    }
+                });
+                return;
+            }
+
             this.detailsService
-                .findById(parseInt(idOrAddress, 10), req.user?.address, req.query)
+                .findById(communityId, req.user?.address, req.query)
                 .then(community => standardResponse(res, 200, true, community))
                 .catch(e => standardResponse(res, 400, false, '', { error: e }));
         }


### PR DESCRIPTION
This PR fixes #1045 

## Changes
We are receiving some requests with the community id/address `undefined`
```
20-11-2023 13:09:43.000[heroku-logs][INFO][postgres.3691435][heroku][PURPLE] [11-1] sql_error_code = 42703 time_ms = "2023-11-20 16:09:43.169 UTC" pid="1476985" proc_start_time="2023-11-20 16:09:31 UTC" session_id="655b84bb.168979" vtid="7/990919" tid="0" log_line="3" database="d56l4mho1dkh25" connection_source="34.246.134.116(59594)" user="u57h2uepi221ft" application_name="[unknown]" ERROR: column "nan" does not exist at character 1299
20-11-2023 13:09:43.172[heroku-logs][INFO][router][heroku]at=info method=GET path="/api/v2/communities/undefined?state=base" host=impactmarket-api-production.herokuapp.com request_id=3adf607e-c7c7-4969-bfe2-71aa73455374 fwd="3.238.197.136" dyno=web.1 connect=0ms service=7ms status=400 bytes=5899 protocol=https
```

To fix that, the input will be validated before doing the SQL query.

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
