### PR TITLE
[bugfix] lambda orchestrator

### DIFF
--- a/services/orchestrator/handler.ts
+++ b/services/orchestrator/handler.ts
@@ -44,18 +44,23 @@ export const herokuTrigger = async (event: any, context: any) => {
 
             if (tags.Tags && tags.Tags.STAGE === stage) {
                 console.log('updating: ', res.FunctionName);
-                return lambda
-                    .updateFunctionConfiguration({
-                        FunctionName: res.FunctionName!,
-                        Environment: {
-                            Variables: {
-                                ...res.Environment?.Variables,
-                                REDIS_URL,
-                                DATABASE_URL,
+                const config = await lambda.getFunctionConfiguration({
+                    FunctionName: res.FunctionName!,
+                }).promise();
+                if (config.LastUpdateStatus !== 'InProgress') {
+                    return lambda
+                        .updateFunctionConfiguration({
+                            FunctionName: res.FunctionName!,
+                            Environment: {
+                                Variables: {
+                                    ...res.Environment?.Variables,
+                                    REDIS_URL,
+                                    DATABASE_URL,
+                                },
                             },
-                        },
-                    })
-                    .promise();
+                        })
+                        .promise();
+                }
             }
         });
 


### PR DESCRIPTION

## Changes
In a release, heroku triggers multiple times the orchestrator lambda causing the error:
`ResourceConflictException: The operation cannot be performed at this time. An update is in progress for resource`.
To avoid that, first, we need to check the `LastUpdateStatus` of the lambda and if its not `InProgress` continue the updating. 

## Tests
<!---
Specify in which devices were tested, and also, what new automated tests were added or updated.
-->
